### PR TITLE
[#27] Change server stop command to stop/remove only MongoDB and Redis containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ python3 das-cli.py <command> <subcommand> [options]
 - `server stop`: Stop and remove all currently running services.
 - `faas start`: Start an OpenFaaS service.
 - `faas stop`: Stop the running OpenFaaS service.
-- `metta load`: Load Metta file(s) into the Canonical Load service.
+- `metta load`: Load a MeTTa file into the databases
 - `metta validate`: Validate the syntax of a Metta file or directory.
 - `logs redis`: Display Docker container log for Redis
 - `logs mongodb`: Display Docker container log for MongoDB.

--- a/commands/metta.py
+++ b/commands/metta.py
@@ -23,16 +23,16 @@ def metta():
         exit(1)
 
 
-@metta.command(help="Load Metta file(s) into the Canonical Load service.")
+@metta.command(help="Load a MeTTa file into the databases")
 @click.option(
     "--path",
-    help="Specify the path to the Metta file(s) for loading.",
+    help="Specify the path to the Metta file for loading.",
     required=True,
     type=str,
 )
 @click.option(
     "--canonical",
-    help="Load the Metta file(s) as Canonical (default is False).",
+    help="Load the Metta file as Canonical (default is False, only works when combined with --use-poc-loader).",
     required=False,
     is_flag=True,
     default=False,

--- a/commands/server.py
+++ b/commands/server.py
@@ -96,25 +96,8 @@ def stop():
 
     redis_container_name = config.get("redis.container_name")
     mongodb_container_name = config.get("mongodb.container_name")
-    openfaas_container_name = config.get("openfaas.container_name")
-    loader_container_name = config.get("loader.container_name")
 
     click.echo(f"Stopping/Removing Currently Running Services")
-    OpenFaaSContainerService(
-        openfaas_container_name,
-        redis_container_name,
-        mongodb_container_name,
-    ).stop()
-    PocLoaderContainerService(
-        loader_container_name,
-        redis_container_name,
-        mongodb_container_name,
-    ).stop()
-    MettaLoaderContainerService(
-        loader_container_name,
-        redis_container_name,
-        mongodb_container_name,
-    ).stop()
     MongoContainerService(mongodb_container_name).stop()
     RedisContainerService(redis_container_name).stop()
     click.echo(f"Done.")


### PR DESCRIPTION
Closes #27 

* When you type 'server stop,' only shut down the server
* Update README.md