### PR TITLE
[#51] Add minor features to das-cli

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,20 @@
 [#47] Add support to ":" in symbol names
 [#51] Add minor features to das-cli and update documentation
-    Change message showing default version of the running function to show the actual version number.
-    Add a das-cli logs das to follow the DAS log das.log
-    Add das-cli jupyter-notebook start start a jupyter-notebook server running with all required dependencies to use hyperon-das.
-    Adjust runtime messages for das-cli example local and das-cli example faas. Both show python commands
+    das-cli --version
+    das-cli update-version [--version] (defaulted to newest version)
+    Rename das-cli server to das-cli db
     das-cli db restart
     das-cli faas restart
     Remove parameter --path in das-cli metta load and das-cli metta validate and get the input file as a required parameter.
     Rename das-cli metta validate to das-cli metta check.
-    Rename das-cli server to das-cli db
+    das-cli server start should sleep for a couple of seconds after finishing the startup of DB containers 
+    Change message showing default version of the running function to show the actual version number.
+    Add a das-cli logs das to follow the DAS log das.log
+    Add das-cli jupyter-notebook start start a jupyter-notebook server running with all required dependencies to use hyperon-das.
+    Adjust runtime messages for das-cli example local and das-cli example faas. Both show python commands
+    das-cli faas update-version [--version]
+    das-cli faas --version
+    das-cli python-library version: show currently installed and newest available versions of both, hyperon-das and hyperon-das-atomdb
+    das-cli python-library update. Update hyperon-das to the newest available version. As a consequence, hyperon-das-atomdb should be updated to the proper required version as well.
+    das-cli python-library set --hyperon-das 0.4.0 --hyperon-das-atomdb 0.8.2 Allow setting specific versions for both libraries
+    das-cli python-library list by default, list all major/minor versions of hyperon-das and hyperon-das-atomdb. There should have optional parameters --show-patches and --library <xxx>

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ The commands outlined below should be executed within the "src" directory if you
 python3 das_cli.py <command> <subcommand> [options]
 ```
 
+- `--help`: Package help (global flag).
+- `--version`: Package Version.
+- `update-version`: Update Package Version.
 - `example local`: Echo commands for local setup.
 - `example faas`: Echo commands for OpenFaaS setup.
 - `config list`: Display the current configuration settings.
@@ -159,6 +162,8 @@ python3 das_cli.py <command> <subcommand> [options]
 - `faas start`: Start an OpenFaaS service inside a docker container.
 - `faas stop`: Stop and remove the OpenFaaS container.
 - `faas restart`: Restart OpenFaaS container.
+- `faas update-version`: Update an OpenFaaS service to a newer version.
+- `faas version`: Get OpenFaaS function version.
 - `metta load`: Load a MeTTa file into the databases
 - `metta check`: Check the syntax of a Metta file or directory.
 - `logs redis`: Display Docker container log for Redis
@@ -168,6 +173,10 @@ python3 das_cli.py <command> <subcommand> [options]
 - `jupyter-notebook start`: Start a Jupyter Notebook.
 - `jupyter-notebook restart`: Restart Jupyter Notebook.
 - `jupyter-notebook stop`: Stop a Jupyter Notebook.
+- `python-library list`: List all major/minor versions of hyperon-das and hyperon-das-atomdb.
+- `python-library set`: Allow setting specific versions for both hyperon-das and hyperon-das-atomdb libraries
+- `python-library version`: Show currently installed and newest available versions of both, hyperon-das and hyperon-das-atomdb
+- `python-library update`: Update both hyperon-das and hyperon-das-atomdb to the newest available version.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ python3 das_cli.py <command> <subcommand> [options]
 ```
 
 - `--help`: Package help (global flag).
-- `--version`: Package Version.
+- `--version`: Package Version (global flag).
 - `update-version`: Update Package Version.
 - `example local`: Echo commands for local setup.
 - `example faas`: Echo commands for OpenFaaS setup.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ python3 das_cli.py metta check $PWD/examples/data/animals.metta
 python3 das_cli.py metta load $PWD/examples/data/animals.metta
 
 # Start OpenFaaS Service
-python3 das_cli.py faas start --function queryengine --version 1.9.2
+python3 das_cli.py faas start
 
 # Modify the examples/distributed_atom_space_remote.py file with the port openFaaS is running (default 8080).
 python3 examples/distributed_atom_space_remote.py

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -5,3 +5,4 @@ from .metta import metta
 from .example import example
 from .logs import logs
 from .jupyter_notebook import jupyter_notebook
+from .python_library import python_library

--- a/src/commands/config.py
+++ b/src/commands/config.py
@@ -64,6 +64,9 @@ def set():
         openfaas_version = f"latest"
         config_service.set("openfaas.version", openfaas_version)
 
+        openfaas_function = f"queryengine"
+        config_service.set("openfaas.function", openfaas_function)
+
         jupyter_notebook_port = click.prompt(
             "Enter Jupyter Notebook port",
             hide_input=True,

--- a/src/commands/faas.py
+++ b/src/commands/faas.py
@@ -120,9 +120,18 @@ def version():
 def update_version(function, version):
     _validate_version(version)
 
-    config.set("openfaas.version", version)
-    config.set("openfaas.function", function)
-    config.save()
+    function_tag = f"{version}-{function}"
+
+    try:
+        _pull_image(OPENFAAS_IMAGE_NAME, function_tag)
+
+        config.set("openfaas.version", version)
+        config.set("openfaas.function", function)
+        config.save()
+
+        click.secho("Function version successfully updated", fg="green")
+    except Exception as e:
+        _handle_exception(e)
 
 
 @faas.command(help="Restart OpenFaaS service.")

--- a/src/commands/faas.py
+++ b/src/commands/faas.py
@@ -81,7 +81,7 @@ def faas(ctx):
     config = ctx.obj["config"]
 
 
-@faas.command(help="Update an OpenFaaS service to a newer version.")
+@faas.command(help="Get OpenFaaS function version.")
 def version():
     version = config.get("openfaas.version", "latest")
     function = config.get("openfaas.function", FunctionEnum.QUERY_ENGINE.value)

--- a/src/commands/python_library.py
+++ b/src/commands/python_library.py
@@ -3,6 +3,7 @@ import pkg_resources
 import requests
 from exceptions import NotFound
 import subprocess
+import re
 
 
 @click.group(help="")
@@ -39,10 +40,17 @@ def update_python_package_version(package_name, version=None):
 
     pypi_package = f"{package_name}=={version}" if version is not None else package_name
 
-    subprocess.run(
-        ["python", "-m", "pip", "install", "--upgrade", "--quiet", pypi_package],
-        check=True,
-    )
+    try:
+        subprocess.run(
+            ["python", "-m", "pip", "install", "--upgrade", "--quiet", pypi_package],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        raise Exception(
+            f"Failed to update package {package_name}. Please verify if the provided version exists or ensure the package name is correct."
+        )
 
 
 def print_package_info(package_name, current_version, latest_version):
@@ -51,6 +59,12 @@ def print_package_info(package_name, current_version, latest_version):
         f"  INSTALLED: {current_version}\n"
         f"  LATEST:    {latest_version}"
     )
+
+
+def validate_version(version):
+    if not re.match(r"v?\d+\.\d+\.\d+", version):
+        click.secho("The version must follow the format x.x.x (e.g 1.10.9)", fg="red")
+        exit(1)
 
 
 @python_library.command(help="")
@@ -87,6 +101,54 @@ def update():
             exit(1)
 
     click.secho("All package has been successfully updated.", fg="green")
+
+    ctx = click.Context(python_library)
+    ctx.invoke(version)
+
+
+@python_library.command(help="")
+@click.option(
+    "--hyperon-das",
+    type=str,
+    required=False,
+)
+@click.option(
+    "--hyperon-das-atomdb",
+    type=str,
+    required=False,
+)
+def set(hyperon_das, hyperon_das_atomdb):
+    if hyperon_das is None and hyperon_das_atomdb is None:
+        click.secho(
+            "At least one of --hyperon-das or --hyperon-das-atomdb must be provided.",
+            fg="red",
+        )
+        exit(1)
+
+    packages = {
+        "hyperon-das": hyperon_das,
+        "hyperon-das-atomdb": hyperon_das_atomdb,
+    }
+
+    for package_name, package_version in packages.items():
+        if package_version is not None:
+            try:
+                validate_version(package_version)
+                click.echo(f"Updating package {package_name}...")
+                update_python_package_version(package_name, version=package_version)
+                click.secho(
+                    f"Package {package_name} has been successfully updated.",
+                    fg="green",
+                )
+            except NotFound as e:
+                click.secho(str(e), fg="red")
+                exit(1)
+            except Exception as e:
+                click.secho(
+                    f"An error occurred while trying to update {package_name}: {str(e)}",
+                    fg="red",
+                )
+                exit(1)
 
     ctx = click.get_current_context()
     ctx.invoke(version)

--- a/src/commands/python_library.py
+++ b/src/commands/python_library.py
@@ -1,0 +1,92 @@
+import click
+import pkg_resources
+import requests
+from exceptions import NotFound
+import subprocess
+
+
+@click.group(help="")
+@click.pass_context
+def python_library(ctx):
+    global config
+
+    config = ctx.obj["config"]
+
+
+def get_python_package_version(package_name):
+    try:
+        versao = pkg_resources.get_distribution(package_name).version
+        return versao
+    except pkg_resources.DistributionNotFound:
+        raise NotFound(f"Package '{package_name}' is not installed.")
+
+
+def get_latest_python_package_version(package_name):
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+        return data["info"]["version"]
+    except requests.exceptions.RequestException as e:
+        raise NotFound(
+            f"Error while fetching the latest version of the package '{package_name}': {e}"
+        )
+
+
+def update_python_package_version(package_name, version=None):
+    get_python_package_version(package_name)
+
+    pypi_package = f"{package_name}=={version}" if version is not None else package_name
+
+    subprocess.run(
+        ["python", "-m", "pip", "install", "--upgrade", "--quiet", pypi_package],
+        check=True,
+    )
+
+
+def print_package_info(package_name, current_version, latest_version):
+    click.echo(
+        f"{package_name}\n"
+        f"  INSTALLED: {current_version}\n"
+        f"  LATEST:    {latest_version}"
+    )
+
+
+@python_library.command(help="")
+def version():
+    packages = ["hyperon-das", "hyperon-das-atomdb"]
+
+    try:
+        for package in packages:
+            current_version = get_python_package_version(package)
+            latest_version = get_latest_python_package_version(package)
+            print_package_info(package, current_version, latest_version)
+
+    except Exception as e:
+        click.secho(f"{str(e)}", fg="red")
+        exit(1)
+
+
+@python_library.command(help="")
+def update():
+    packages = ["hyperon-das", "hyperon-das-atomdb"]
+
+    for package in packages:
+        try:
+            click.echo(f"Updating package {package}...")
+            update_python_package_version(package)
+        except NotFound as e:
+            click.secho(f"{str(e)}", fg="red")
+            exit(1)
+        except Exception as e:
+            click.secho(
+                f"An error occurred while trying to update {package}: {str(e)}",
+                fg="red",
+            )
+            exit(1)
+
+    click.secho("All package has been successfully updated.", fg="green")
+
+    ctx = click.get_current_context()
+    ctx.invoke(version)

--- a/src/commands/python_library.py
+++ b/src/commands/python_library.py
@@ -112,7 +112,9 @@ def print_versions(versions):
         click.echo(line)
 
 
-@python_library.command(help="")
+@python_library.command(
+    help="Show currently installed and newest available versions of both, hyperon-das and hyperon-das-atomdb"
+)
 def version():
     packages = ["hyperon-das", "hyperon-das-atomdb"]
 
@@ -127,7 +129,9 @@ def version():
         exit(1)
 
 
-@python_library.command(help="")
+@python_library.command(
+    help="Update both hyperon-das and hyperon-das-atomdb to the newest available version."
+)
 def update():
     packages = ["hyperon-das", "hyperon-das-atomdb"]
 
@@ -151,7 +155,10 @@ def update():
     ctx.invoke(version)
 
 
-@python_library.command(name="set", help="")
+@python_library.command(
+    name="set",
+    help="Allow setting specific versions for both hyperon-das and hyperon-das-atomdb libraries",
+)
 @click.option(
     "--hyperon-das",
     type=str,

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,3 +1,5 @@
+VERSION = "0.2.3"
+
 # PATHS
 
 USER_DAS_PATH = "~/.das"

--- a/src/das_cli.py
+++ b/src/das_cli.py
@@ -1,6 +1,15 @@
 import click
 from sys import exit
-from commands import config, db, faas, metta, example, logs, jupyter_notebook
+from commands import (
+    config,
+    db,
+    faas,
+    metta,
+    example,
+    logs,
+    jupyter_notebook,
+    python_library,
+)
 from config import Secret, SECRETS_PATH, USER_DAS_PATH, VERSION
 from services import PackageService
 from exceptions import NotFound
@@ -80,6 +89,7 @@ das_cli.add_command(metta)
 das_cli.add_command(example)
 das_cli.add_command(logs)
 das_cli.add_command(jupyter_notebook)
+das_cli.add_command(python_library)
 
 if __name__ == "__main__":
     das_cli()

--- a/src/das_cli.py
+++ b/src/das_cli.py
@@ -2,6 +2,8 @@ import click
 from sys import exit
 from commands import config, db, faas, metta, example, logs, jupyter_notebook
 from config import Secret, SECRETS_PATH, USER_DAS_PATH
+from services import PackageService
+from exceptions import NotFound
 
 
 @click.group()
@@ -14,6 +16,75 @@ def das_cli(ctx):
     except PermissionError:
         click.secho(
             f"\nIt seems that you don't have the required permissions to write to {SECRETS_PATH}.\n\nTo resolve this, please make sure you are the owner of the file by running: `sudo chown $USER:$USER {USER_DAS_PATH} -R`, and then grant the necessary permissions using: `sudo chmod 770 {USER_DAS_PATH} -R`\n",
+            fg="red",
+        )
+        exit(1)
+
+
+@das_cli.command(help="Get Package Version.")
+def version():
+    package_name = "das-cli"
+
+    if not PackageService.is_ubuntu():
+        click.secho("This command can only be used on Ubuntu.", fg="red")
+        exit(1)
+
+    try:
+        package_installed = PackageService.is_package_installed(package_name)
+
+        if package_installed:
+            package_version = PackageService.get_version(package_name)
+            click.secho(
+                f"{package_version}",
+                fg="green",
+            )
+        else:
+            raise NotFound()
+
+    except NotFound:
+        click.secho(
+            f"The package {package_name} can only be updated if you installed it via apt.",
+            fg="red",
+        )
+        exit(1)
+
+
+@das_cli.command(help="Update Package Version.")
+@click.option(
+    "--version",
+    help="Specify the version of the package (format: x.x.x).",
+    required=False,
+    type=str,
+    default=None,
+)
+def update_version(version):
+    package_name = "das-cli"
+
+    if not PackageService.is_ubuntu():
+        click.secho("This command can only be used on Ubuntu.", fg="red")
+        exit(1)
+
+    try:
+        package_installed = PackageService.is_package_installed(package_name)
+
+        if package_installed:
+            PackageService.install_package(package_name, version)
+            click.secho(
+                f"The package {package_name} has been updated to version {version}.",
+                fg="green",
+            )
+        else:
+            raise NotFound()
+
+    except NotFound:
+        click.secho(
+            f"The package {package_name} can only be updated if you installed it via apt.",
+            fg="red",
+        )
+        exit(1)
+    except Exception:
+        click.secho(
+            f"The {package_name} could not be updated. Please check if the specified version exists.",
             fg="red",
         )
         exit(1)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 Click==7.0
 docker==7.0.0
+distro==1.9.0

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -8,3 +8,4 @@ from .mongo_container_service import MongoContainerService
 from .openfaas_container_service import OpenFaaSContainerService
 from .redis_container_service import RedisContainerService
 from .image_service import ImageService
+from .package_service import PackageService

--- a/src/services/openfaas_container_service.py
+++ b/src/services/openfaas_container_service.py
@@ -76,7 +76,7 @@ class OpenFaaSContainerService(ContainerService):
             # print(e.explanation) # TODO: ADD TO LOGGING FILE
             if e.response.reason == "Not Found":
                 raise NotFound(
-                    f"The image {self.get_container().get_image()} for the function was not found in the Docker Hub repository."
+                    f"The image {self.get_container().get_image()} for the function was not found in the Docker Hub repository. Please verify the existence of the version or ensure the correct function name is used."
                 )
 
             raise DockerException(e.explanation)

--- a/src/services/package_service.py
+++ b/src/services/package_service.py
@@ -1,0 +1,70 @@
+import subprocess
+from typing import Union
+
+
+class PackageService:
+    @staticmethod
+    def is_ubuntu():
+        try:
+            with open("/etc/os-release", "r") as f:
+                for line in f:
+                    if line.startswith("ID="):
+                        return line.strip().split("=")[1].strip('"') == "ubuntu"
+            return False
+        except FileNotFoundError:
+            return False
+
+    @staticmethod
+    def is_package_installed(package_name: str) -> bool:
+        try:
+            subprocess.check_output(
+                [
+                    "dpkg",
+                    "-s",
+                    package_name,
+                ],
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    @staticmethod
+    def get_version(package_name: str) -> str:
+        try:
+            output = subprocess.check_output(["dpkg", "-s", package_name], text=True)
+            for line in output.split("\n"):
+                if line.startswith("Version:"):
+                    return line.split(":")[1].strip()
+        except subprocess.CalledProcessError:
+            return None
+
+    @staticmethod
+    def install_package(package_name: str, version: Union[str, None]) -> None:
+        if version is None:
+            subprocess.run(
+                [
+                    "sudo",
+                    "apt",
+                    "install",
+                    "--only-upgrade",
+                    f"{package_name}",
+                    "-y",
+                ],
+                check=True,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            subprocess.run(
+                [
+                    "sudo",
+                    "apt",
+                    "install",
+                    "--only-upgrade",
+                    "--allow-downgrades",
+                    f"{package_name}={version}",
+                    "-y",
+                ],
+                check=True,
+                stderr=subprocess.DEVNULL,
+            )

--- a/src/services/package_service.py
+++ b/src/services/package_service.py
@@ -4,17 +4,6 @@ from typing import Union
 
 class PackageService:
     @staticmethod
-    def is_ubuntu():
-        try:
-            with open("/etc/os-release", "r") as f:
-                for line in f:
-                    if line.startswith("ID="):
-                        return line.strip().split("=")[1].strip('"') == "ubuntu"
-            return False
-        except FileNotFoundError:
-            return False
-
-    @staticmethod
     def is_package_installed(package_name: str) -> bool:
         try:
             subprocess.check_output(
@@ -28,16 +17,6 @@ class PackageService:
             return True
         except subprocess.CalledProcessError:
             return False
-
-    @staticmethod
-    def get_version(package_name: str) -> str:
-        try:
-            output = subprocess.check_output(["dpkg", "-s", package_name], text=True)
-            for line in output.split("\n"):
-                if line.startswith("Version:"):
-                    return line.split(":")[1].strip()
-        except subprocess.CalledProcessError:
-            return None
 
     @staticmethod
     def install_package(package_name: str, version: Union[str, None]) -> None:


### PR DESCRIPTION
- das-cli --version
- das-cli update-version [--version] (defaulted to newest version)
- das-cli faas update-version [--version]
- das-cli faas --version
- das-cli python-library version: show currently installed and newest available versions of both, hyperon-das and hyperon-das-atomdb
- das-cli python-library update. Update hyperon-das to the newest available version. As a consequence, hyperon-das-atomdb should be updated to the proper required version as well.
- das-cli python-library set --hyperon-das 0.4.0 --hyperon-das-atomdb 0.8.2 Allow setting specific versions for both libraries
- das-cli python-library list by default, list all major/minor versions of hyperon-das and hyperon-das-atomdb. There should have optional parameters --show-patches and --library <xxx>
