### PR TITLE
[#85] Fix man page generation by restructuring das-cli entrypoint

### DIFF
--- a/src/commands/db/db_cli.py
+++ b/src/commands/db/db_cli.py
@@ -244,8 +244,8 @@ $ das-cli db restart
         self._db_stop = db_stop
 
     def run(self):
-        self._db_stop.run()
-        self._db_start.run()
+        self._db_stop.safe_run()
+        self._db_start.safe_run()
 
 
 class DbCli(CommandGroup):

--- a/src/commands/faas/faas_cli.py
+++ b/src/commands/faas/faas_cli.py
@@ -216,8 +216,8 @@ $ das-cli faas restart
         self._faas_stop = faas_stop
 
     def run(self):
-        self._faas_stop.run()
-        self._faas_start.run()
+        self._faas_stop.safe_run()
+        self._faas_start.safe_run()
 
 
 class FaaSVersion(Command):

--- a/src/commands/jupyter_notebook/jupyter_notebook_cli.py
+++ b/src/commands/jupyter_notebook/jupyter_notebook_cli.py
@@ -134,8 +134,8 @@ $ das-cli jupyter-notebook restart
         self._jupyter_notebook_stop = jupyter_notebook_stop
 
     def run(self):
-        self._jupyter_notebook_stop.run()
-        self._jupyter_notebook_start.run()
+        self._jupyter_notebook_stop.safe_run()
+        self._jupyter_notebook_start.safe_run()
 
 
 class JupyterNotebookCli(CommandGroup):

--- a/src/commands/python_library/python_library_cli.py
+++ b/src/commands/python_library/python_library_cli.py
@@ -217,7 +217,7 @@ $ das-cli python-library set --hyperon-das-atomdb=0.4.0
                 "All package has been successfully updated.",
                 severity=StdoutSeverity.SUCCESS,
             )
-            self._python_library_version.run()
+            self._python_library_version.safe_run()
         else:
             self.stdout(
                 "One or more packages could not be updated.",
@@ -268,7 +268,7 @@ $ das-cli python-library update
                 "All package has been successfully updated.",
                 severity=StdoutSeverity.SUCCESS,
             )
-            self._python_library_version.run()
+            self._python_library_version.safe_run()
         else:
             self.stdout(
                 "One or more packages could not be updated.",

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -10,6 +10,11 @@ from .command import (
 )
 from .prompt_types import IntRange, ReachableIpAddress, Choice, FunctionVersion, Path
 from .docker import RemoteContextManager, ContainerManager, Container, ImageManager
-from .network import get_public_ip, get_server_username
-from .utils import get_script_name, is_executable_bin, remove_special_characters
+from .network import get_public_ip
+from .utils import (
+    get_script_name,
+    is_executable_bin,
+    remove_special_characters,
+    get_server_username,
+)
 from .logger import logger

--- a/src/common/command.py
+++ b/src/common/command.py
@@ -36,11 +36,23 @@ class Command:
     def __init__(self) -> None:
         self.command = click.Command(
             name=self.name,
-            callback=self.run,
+            callback=self.safe_run,
             help=self.help,
             short_help=self.short_help,
             params=self.params,
         )
+
+    def safe_run(self, **kwarg):
+        try:
+            return self.run(**kwarg)
+        except Exception as e:
+            error_type = e.__class__.__name__
+            error_message = str(e)
+            pretty_message = f"\033[31m[{error_type}] {error_message}\033[39m"
+
+            logger().exception(error_message)
+
+            print(pretty_message)
 
     def prompt(
         self,

--- a/src/common/docker/docker_manager.py
+++ b/src/common/docker/docker_manager.py
@@ -1,0 +1,34 @@
+import docker
+from typing import AnyStr, Union
+from .exceptions import (
+    DockerContextError,
+    DockerDaemonConnectionError,
+)
+
+
+class DockerManager:
+    def __init__(
+        self,
+        exec_context: Union[AnyStr, None] = None,
+    ) -> None:
+        self._exec_context = exec_context
+
+    def _get_client(self, use: Union[AnyStr, None] = None) -> docker.DockerClient:
+        context = docker.ContextAPI.get_context(use)
+        if context is None:
+            raise DockerContextError(f"Docker context {use!r} not found")
+        try:
+            return docker.DockerClient(
+                base_url=context.endpoints["docker"]["Host"],
+                use_ssh_client=True,
+            )
+        except Exception as e:
+            raise e
+
+    def get_docker_client(self) -> docker.DockerClient:
+        try:
+            return self._get_client(self._exec_context)
+        except docker.errors.DockerException:
+            raise DockerDaemonConnectionError(
+                "Your Docker service appears to be either malfunctioning or not running."
+            )

--- a/src/common/docker/image_manager.py
+++ b/src/common/docker/image_manager.py
@@ -1,27 +1,19 @@
 import docker
 from typing import Union
+from .docker_manager import DockerManager
 from .exceptions import (
-    DockerDaemonConnectionError,
     DockerImageNotFoundError,
     DockerError,
 )
 
 
-class ImageManager:
-    def __init__(self) -> None:
-        try:
-            self._docker_client = docker.from_env()
-        except docker.errors.DockerException:
-            raise DockerDaemonConnectionError(
-                "Your Docker service appears to be either malfunctioning or not running."
-            )
-
+class ImageManager(DockerManager):
     def format_function_tag(self, function, version) -> str:
         return f"{function}-{version}"
 
     def pull(self, repository, image_tag) -> None:
         try:
-            self._docker_client.images.pull(repository, image_tag)
+            self.get_docker_client().images.pull(repository, image_tag)
         except docker.errors.APIError as e:
             if e.response.reason == "Not Found":
                 raise DockerImageNotFoundError(
@@ -36,7 +28,7 @@ class ImageManager:
         image = f"{repository}:{tag}"
 
         try:
-            container = self._docker_client.api.inspect_image(image)
+            container = self.get_docker_client().api.inspect_image(image)
 
             labels = container["Config"]["Labels"]
 

--- a/src/common/network.py
+++ b/src/common/network.py
@@ -1,6 +1,5 @@
 import subprocess
 import requests
-import getpass
 from typing import Union
 import re
 
@@ -10,10 +9,6 @@ def get_public_ip():
         return requests.get("https://api.ipify.org").content.decode("utf8")
     except:
         return None
-
-
-def get_server_username() -> str:
-    return getpass.getuser()
 
 
 # TODO: validate ip

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import getpass
 
 
 def is_executable_bin():
@@ -11,6 +12,10 @@ def get_script_name():
         return os.path.basename(sys.executable)
     else:
         return "python3 " + sys.argv[0]
+
+
+def get_server_username() -> str:
+    return getpass.getuser()
 
 
 def remove_special_characters(text):

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,3 +1,5 @@
+from common.utils import get_server_username
+
 VERSION = "0.2.18"
 RELEASE_NOTES_URL = (
     "https://raw.githubusercontent.com/singnet/das/master/docs/release-notes.md"
@@ -11,7 +13,8 @@ SECRETS_PATH = f"{USER_DAS_PATH}/config.json"
 
 # LOG
 
-LOG_FILE_NAME = "/tmp/das.log"
+LOG_FILE_DIR = get_server_username()
+LOG_FILE_NAME = f"/tmp/{LOG_FILE_DIR}-das-cli.log"
 
 # SERVICES
 

--- a/src/das_cli.py
+++ b/src/das_cli.py
@@ -9,7 +9,6 @@ from commands.release_notes import ReleaseNotesModule
 from commands.logs import LogsModule
 from commands.metta import MettaModule
 from commands.das import DasModule
-from common.logger import logger
 
 MODULES = [
     ConfigModule,
@@ -44,20 +43,8 @@ def init_cli(module):
     return instance.group
 
 
-def das_cli():
-    try:
-        cli = init_cli(DasModule)
-        init_modules(cli)
-        cli()
-    except Exception as e:
-        error_type = e.__class__.__name__
-        error_message = str(e)
-        pretty_message = f"\033[31m[{error_type}] {error_message}\033[39m"
-
-        logger().exception(error_message)
-
-        print(pretty_message)
-
+das_cli = init_cli(DasModule)
+init_modules(das_cli)
 
 if __name__ == "__main__":
     das_cli()

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-from config import VERSION
+from config.config import VERSION
 
 setup(
     name="das-cli",


### PR DESCRIPTION
Closes #85 

- Resolved issue with click-man expecting a group object instead of a function.
- Refactored the das-cli entrypoint to properly use a group object.
- Moved error handling to a new method called `safe_run`.