### PR TITLE
[DAS-Dashboard #1183] Surpress browser password manager behavior

### DIFF
--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { ClusterForm } from "../ClusterForm"
 import { parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -31,6 +31,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="Redis Endpoint"
             size="small"
             required
+            {...disableAutofillField}
             defaultValue={form.current.redis_endpoint}
             onChange={(e) => {
               form.current.redis_endpoint = e.target.value
@@ -59,6 +60,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="MongoDB Endpoint"
             size="small"
             required
+            {...disableAutofillField}
             defaultValue={form.current.mongo_endpoint}
             onChange={(e) => {
               form.current.mongo_endpoint = e.target.value
@@ -175,6 +177,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="MorkDB Endpoint"
             size="small"
             required
+            {...disableAutofillField}
             defaultValue={form.current.mork_endpoint}
             onChange={(e) => {
               form.current.mork_endpoint = e.target.value
@@ -203,6 +206,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="MongoDB Endpoint"
             size="small"
             required
+            {...disableAutofillField}
             defaultValue={form.current.mongo_endpoint}
             onChange={(e) => {
               form.current.mongo_endpoint = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
@@ -101,7 +101,6 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
           <TextField
             fullWidth
             label="MongoDB Password"
-            type="password"
             size="small"
             required
             {...credentialPasswordField}
@@ -247,7 +246,6 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
           <TextField
             fullWidth
             label="MongoDB Password"
-            type="password"
             size="small"
             required
             {...credentialPasswordField}

--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterBackendOptions.jsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { ClusterForm } from "../ClusterForm"
 import { parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -86,6 +87,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="MongoDB Username"
             size="small"
             required
+            {...credentialUsernameField}
             defaultValue={form.current.mongo_username}
             onChange={(e) => {
               form.current.mongo_username = e.target.value
@@ -100,6 +102,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             type="password"
             size="small"
             required
+            {...credentialPasswordField}
             defaultValue={form.current.mongo_password}
             onChange={(e) => {
               form.current.mongo_password = e.target.value
@@ -228,6 +231,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             label="MongoDB Username"
             size="small"
             required
+            {...credentialUsernameField}
             defaultValue={form.current.mongo_username}
             onChange={(e) => {
               form.current.mongo_username = e.target.value
@@ -242,6 +246,7 @@ export function AdapterBackendOptions({ backendType, backendRef }) {
             type="password"
             size="small"
             required
+            {...credentialPasswordField}
             defaultValue={form.current.mongo_password}
             onChange={(e) => {
               form.current.mongo_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
@@ -19,6 +19,7 @@ import { MANAGED_CONTEXT_MAPPING_PATH } from "./adapterConstants"
 import { initAdapterBackend, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField, pathField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import { AdapterBackendOptions } from "./AdapterBackendOptions"
 import {
   GridSpan9,
@@ -221,6 +222,7 @@ export function AdapterDBOptions() {
           label="Username"
           size="small"
           required
+          {...credentialUsernameField}
           defaultValue={form.current.db_username}
           onChange={(e) => {
             form.current.db_username = e.target.value
@@ -235,6 +237,7 @@ export function AdapterDBOptions() {
           type="password"
           size="small"
           required
+          {...credentialPasswordField}
           defaultValue={form.current.db_password}
           onChange={(e) => {
             form.current.db_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
@@ -19,7 +19,7 @@ import { MANAGED_CONTEXT_MAPPING_PATH } from "./adapterConstants"
 import { initAdapterBackend, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField, pathField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import { AdapterBackendOptions } from "./AdapterBackendOptions"
 import {
   GridSpan9,
@@ -149,6 +149,7 @@ export function AdapterDBOptions() {
           label="Adapter Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.adapter_endpoint}
           onChange={(e) => {
             form.current.adapter_endpoint = e.target.value
@@ -181,6 +182,7 @@ export function AdapterDBOptions() {
           label="Database Host"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.db_host}
           onChange={(e) => {
             form.current.db_host = e.target.value
@@ -209,6 +211,7 @@ export function AdapterDBOptions() {
           label="Database Name"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.db_name}
           onChange={(e) => {
             form.current.db_name = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/AdapterDB/AdapterDB.jsx
@@ -237,7 +237,6 @@ export function AdapterDBOptions() {
         <TextField
           fullWidth
           label="Password"
-          type="password"
           size="small"
           required
           {...credentialPasswordField}

--- a/das-dashboard/src/components/configuration_page/AtomDB/ClusterForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/ClusterForm.jsx
@@ -2,6 +2,7 @@ import { Box, Button, TextField, Typography, IconButton } from "@mui/material"
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline"
 import { useEffect, useRef, useState } from "react"
 import { ipv4Field } from "../formValidation"
+import { credentialUsernameField } from "../../../utils/credentialFieldProps"
 
 function normalizeNodeContext(context) {
   if (!context || context === "default") {
@@ -113,6 +114,7 @@ export function ClusterForm({ type, initialNodes = [], onChange }) {
               size="small"
               margin="none"
               required
+              {...credentialUsernameField}
               defaultValue={node.username ?? ""}
               onChange={(e) => {
                 updateNode(i, "username", e.target.value)

--- a/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
@@ -6,6 +6,7 @@ import { useToast } from "../../../global_providers/ToastProvider"
 import { initMorkMongoConnection, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -96,6 +97,7 @@ export function MorkMongoOptions() {
           label="MongoDB Username"
           size="small"
           required
+          {...credentialUsernameField}
           defaultValue={form.current.mongo_username}
           onChange={(e) => {
             form.current.mongo_username = e.target.value
@@ -110,6 +112,7 @@ export function MorkMongoOptions() {
           type="password"
           size="small"
           required
+          {...credentialPasswordField}
           defaultValue={form.current.mongo_password}
           onChange={(e) => {
             form.current.mongo_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
@@ -6,7 +6,7 @@ import { useToast } from "../../../global_providers/ToastProvider"
 import { initMorkMongoConnection, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -41,6 +41,7 @@ export function MorkMongoOptions() {
           label="MorkDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mork_endpoint}
           onChange={(e) => {
             form.current.mork_endpoint = e.target.value
@@ -69,6 +70,7 @@ export function MorkMongoOptions() {
           label="MongoDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mongo_endpoint}
           onChange={(e) => {
             form.current.mongo_endpoint = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/MorkMongo/MorkMongo.jsx
@@ -111,7 +111,6 @@ export function MorkMongoOptions() {
         <TextField
           fullWidth
           label="MongoDB Password"
-          type="password"
           size="small"
           required
           {...credentialPasswordField}

--- a/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
@@ -6,7 +6,7 @@ import { useToast } from "../../../global_providers/ToastProvider"
 import { initRedisMongoConnection, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -42,6 +42,7 @@ export function RedisMongoOptions() {
           label="Redis Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.redis_endpoint}
           onChange={(e) => {
             form.current.redis_endpoint = e.target.value
@@ -70,6 +71,7 @@ export function RedisMongoOptions() {
           label="MongoDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mongo_endpoint}
           onChange={(e) => {
             form.current.mongo_endpoint = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
@@ -6,6 +6,7 @@ import { useToast } from "../../../global_providers/ToastProvider"
 import { initRedisMongoConnection, parsePortValue } from "../../configFormUtils"
 import { ConfigForm } from "../../ConfigForm"
 import { portField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import {
   GridSpan9,
   GridSpan3,
@@ -97,6 +98,7 @@ export function RedisMongoOptions() {
           label="MongoDB Username"
           size="small"
           required
+          {...credentialUsernameField}
           defaultValue={form.current.mongo_username}
           onChange={(e) => {
             form.current.mongo_username = e.target.value
@@ -111,6 +113,7 @@ export function RedisMongoOptions() {
           type="password"
           size="small"
           required
+          {...credentialPasswordField}
           defaultValue={form.current.mongo_password}
           onChange={(e) => {
             form.current.mongo_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RedisMongo/RedisMongo.jsx
@@ -112,7 +112,6 @@ export function RedisMongoOptions() {
         <TextField
           fullWidth
           label="MongoDB Password"
-          type="password"
           size="small"
           required
           {...credentialPasswordField}

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react"
 import { useConfig } from "../../../global_providers/ConfigurationProvider"
 import { initMorkMongoConnection, parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import { GridSpan3, GridSpan9 } from "../AtomDBStyled"
 
 export function MorkMongoSubForm({ onChange, category }) {
@@ -30,6 +30,7 @@ export function MorkMongoSubForm({ onChange, category }) {
           label="MorkDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mork_endpoint}
           onChange={(e) => {
             form.current.mork_endpoint = e.target.value
@@ -60,6 +61,7 @@ export function MorkMongoSubForm({ onChange, category }) {
           label="MongoDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mongo_endpoint}
           onChange={(e) => {
             form.current.mongo_endpoint = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react"
 import { useConfig } from "../../../global_providers/ConfigurationProvider"
 import { initMorkMongoConnection, parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import { GridSpan3, GridSpan9 } from "../AtomDBStyled"
 
 export function MorkMongoSubForm({ onChange, category }) {
@@ -89,6 +90,7 @@ export function MorkMongoSubForm({ onChange, category }) {
           label="Mongo User"
           size="small"
           required
+          {...credentialUsernameField}
           defaultValue={form.current.mongo_username}
           onChange={(e) => {
             form.current.mongo_username = e.target.value
@@ -104,6 +106,7 @@ export function MorkMongoSubForm({ onChange, category }) {
           size="small"
           type="password"
           required
+          {...credentialPasswordField}
           defaultValue={form.current.mongo_password}
           onChange={(e) => {
             form.current.mongo_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/MorkMongoSubForm.jsx
@@ -106,7 +106,6 @@ export function MorkMongoSubForm({ onChange, category }) {
           fullWidth
           label="Mongo Pass"
           size="small"
-          type="password"
           required
           {...credentialPasswordField}
           defaultValue={form.current.mongo_password}

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react"
 import { useConfig } from "../../../global_providers/ConfigurationProvider"
 import { initRedisMongoConnection, parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
-import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
+import { credentialPasswordField, credentialUsernameField, disableAutofillField } from "../../../../utils/credentialFieldProps"
 import { GridSpan3, GridSpan9 } from "../AtomDBStyled"
 
 export function RedisMongoSubForm({ onChange, category }) {
@@ -30,6 +30,7 @@ export function RedisMongoSubForm({ onChange, category }) {
           label="Redis Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.redis_endpoint}
           onChange={(e) => {
             form.current.redis_endpoint = e.target.value
@@ -60,6 +61,7 @@ export function RedisMongoSubForm({ onChange, category }) {
           label="MongoDB Endpoint"
           size="small"
           required
+          {...disableAutofillField}
           defaultValue={form.current.mongo_endpoint}
           onChange={(e) => {
             form.current.mongo_endpoint = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react"
 import { useConfig } from "../../../global_providers/ConfigurationProvider"
 import { initRedisMongoConnection, parsePortValue } from "../../configFormUtils"
 import { portField } from "../../formValidation"
+import { credentialPasswordField, credentialUsernameField } from "../../../../utils/credentialFieldProps"
 import { GridSpan3, GridSpan9 } from "../AtomDBStyled"
 
 export function RedisMongoSubForm({ onChange, category }) {
@@ -89,6 +90,7 @@ export function RedisMongoSubForm({ onChange, category }) {
           label="Mongo User"
           size="small"
           required
+          {...credentialUsernameField}
           defaultValue={form.current.mongo_username}
           onChange={(e) => {
             form.current.mongo_username = e.target.value
@@ -104,6 +106,7 @@ export function RedisMongoSubForm({ onChange, category }) {
           size="small"
           type="password"
           required
+          {...credentialPasswordField}
           defaultValue={form.current.mongo_password}
           onChange={(e) => {
             form.current.mongo_password = e.target.value

--- a/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
+++ b/das-dashboard/src/components/configuration_page/AtomDB/RemoteDB/RedisMongoSubForm.jsx
@@ -106,7 +106,6 @@ export function RedisMongoSubForm({ onChange, category }) {
           fullWidth
           label="Mongo Pass"
           size="small"
-          type="password"
           required
           {...credentialPasswordField}
           defaultValue={form.current.mongo_password}

--- a/das-dashboard/src/components/configuration_page/ConfigForm.jsx
+++ b/das-dashboard/src/components/configuration_page/ConfigForm.jsx
@@ -4,6 +4,7 @@ export function ConfigForm({ onSubmit, children, sx }) {
   return (
     <Box
       component="form"
+      autoComplete="off"
       sx={{ display: "contents", ...sx }}
       onSubmit={(event) => {
         event.preventDefault()

--- a/das-dashboard/src/components/configuration_page/formValidation.js
+++ b/das-dashboard/src/components/configuration_page/formValidation.js
@@ -56,7 +56,18 @@ export const spreadUpperInput = {
 }
 
 export function field(rules) {
-  return { slotProps: { htmlInput: rules } }
+  return {
+    autoComplete: "off",
+    slotProps: {
+      htmlInput: {
+        autoComplete: "off",
+        "data-form-type": "other",
+        "data-lpignore": "true",
+        "data-1p-ignore": "true",
+        ...rules
+      }
+    }
+  }
 }
 
 export const ipv4Field = field(ipv4Input)
@@ -70,8 +81,13 @@ export const spreadLowerField = field(spreadLowerInput)
 export const spreadUpperField = field(spreadUpperInput)
 
 export const numberField = {
+  autoComplete: "off",
   slotProps: {
     htmlInput: {
+      autoComplete: "off",
+      "data-form-type": "other",
+      "data-lpignore": "true",
+      "data-1p-ignore": "true",
       ...nonNegativeInput,
       onWheel: (event) => event.target.blur()
     }

--- a/das-dashboard/src/pages/profile/ProfilePage.jsx
+++ b/das-dashboard/src/pages/profile/ProfilePage.jsx
@@ -4,6 +4,7 @@ import { PageContainer } from "./profilepage.styled";
 import { useToast } from "../../components/global_providers/ToastProvider";
 import { createProfile, getProfile } from "../../api/ProfileAPI";
 import { extractErrorDetails } from "../../api/APIUtils";
+import { credentialUsernameField } from "../../utils/credentialFieldProps";
 
 export default function ProfilePage() {
   const { showToast } = useToast();
@@ -70,8 +71,21 @@ export default function ProfilePage() {
       <Paper elevation={2} sx={{ width: "100%", maxWidth: 520, p: 4, borderRadius: 3 }}>
         <Typography variant="h5" fontWeight={700} mb={3}>SSH Profile</Typography>
 
-        <Box display="flex" flexDirection="column" gap={3}>
-          <TextField label="SSH Username" value={form.sshUsername} onChange={handleChange("sshUsername")} fullWidth />
+        <Box
+          component="form"
+          autoComplete="off"
+          display="flex"
+          flexDirection="column"
+          gap={3}
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <TextField
+            label="SSH Username"
+            value={form.sshUsername}
+            onChange={handleChange("sshUsername")}
+            fullWidth
+            {...credentialUsernameField}
+          />
           <TextField label="SSH Key File" value={form.sshKeyFile?.name || ""} fullWidth disabled />
 
           <Button variant="outlined" component="label">

--- a/das-dashboard/src/pages/profile/ProfilePage.jsx
+++ b/das-dashboard/src/pages/profile/ProfilePage.jsx
@@ -80,7 +80,7 @@ export default function ProfilePage() {
           onSubmit={(event) => event.preventDefault()}
         >
           <TextField
-            label="SSH Username"
+            label="SSH user"
             value={form.sshUsername}
             onChange={handleChange("sshUsername")}
             fullWidth

--- a/das-dashboard/src/utils/credentialFieldProps.js
+++ b/das-dashboard/src/utils/credentialFieldProps.js
@@ -1,23 +1,46 @@
+const autofillOffInput = {
+  autoComplete: "off",
+  "data-form-type": "other",
+  "data-lpignore": "true",
+  "data-1p-ignore": "true"
+};
+
+const unlockOnFocusInput = {
+  readOnly: true,
+  onFocus: (event) => {
+    event.target.readOnly = false;
+  }
+};
+
+export const disableAutofillField = {
+  autoComplete: "off",
+  slotProps: {
+    htmlInput: {
+      ...autofillOffInput
+    }
+  }
+};
+
 export const credentialUsernameField = {
   autoComplete: "off",
   slotProps: {
     htmlInput: {
-      autoComplete: "off",
-      "data-form-type": "other",
-      "data-lpignore": "true",
-      "data-1p-ignore": "true"
+      ...autofillOffInput,
+      ...unlockOnFocusInput
     }
   }
 };
 
 export const credentialPasswordField = {
-  autoComplete: "new-password",
+  autoComplete: "off",
   slotProps: {
     htmlInput: {
-      autoComplete: "new-password",
+      // Avoid "new-password" — Chrome treats that as sign-up and offers to generate.
+      autoComplete: "one-time-code",
       "data-form-type": "other",
       "data-lpignore": "true",
-      "data-1p-ignore": "true"
+      "data-1p-ignore": "true",
+      ...unlockOnFocusInput
     }
   }
 };

--- a/das-dashboard/src/utils/credentialFieldProps.js
+++ b/das-dashboard/src/utils/credentialFieldProps.js
@@ -26,20 +26,26 @@ export const credentialUsernameField = {
   slotProps: {
     htmlInput: {
       ...autofillOffInput,
+      name: "das-config-user",
       ...unlockOnFocusInput
     }
   }
 };
 
+// Use masked text instead of type="password" so browsers do not treat this as a login form.
 export const credentialPasswordField = {
+  type: "text",
   autoComplete: "off",
+  sx: {
+    "& .MuiInputBase-input": {
+      WebkitTextSecurity: "disc",
+      MozTextSecurity: "disc"
+    }
+  },
   slotProps: {
     htmlInput: {
-      // Avoid "new-password" — Chrome treats that as sign-up and offers to generate.
-      autoComplete: "one-time-code",
-      "data-form-type": "other",
-      "data-lpignore": "true",
-      "data-1p-ignore": "true",
+      ...autofillOffInput,
+      name: "das-config-secret",
       ...unlockOnFocusInput
     }
   }

--- a/das-dashboard/src/utils/credentialFieldProps.js
+++ b/das-dashboard/src/utils/credentialFieldProps.js
@@ -1,0 +1,23 @@
+export const credentialUsernameField = {
+  autoComplete: "off",
+  slotProps: {
+    htmlInput: {
+      autoComplete: "off",
+      "data-form-type": "other",
+      "data-lpignore": "true",
+      "data-1p-ignore": "true"
+    }
+  }
+};
+
+export const credentialPasswordField = {
+  autoComplete: "new-password",
+  slotProps: {
+    htmlInput: {
+      autoComplete: "new-password",
+      "data-form-type": "other",
+      "data-lpignore": "true",
+      "data-1p-ignore": "true"
+    }
+  }
+};


### PR DESCRIPTION
**Small adjustment to the configuration page inputs to reduce Firefox's and other browsers' password manager prompts.**

<img width="921" height="419" alt="Screenshot from 2026-07-24 14-22-33" src="https://github.com/user-attachments/assets/aae6e0d3-1c52-41ad-9dfc-5c402725015f" />

The videos below demonstrate testing on the configuration page while attempting to trigger the browser's password manager.

Firefox test with browser totally clean, no previous config files or browser config:

[Screencast from 2026-07-24 17-12-30.webm](https://github.com/user-attachments/assets/e3553678-445d-4f36-a65c-36f1d6ddbe4a)

Chrome test (chrome was triggering a prompt to auto-generate a new password, also fixed)

[Screencast from 2026-07-24 17-17-27.webm](https://github.com/user-attachments/assets/d3e3c6b6-0d48-494c-8360-4c84ce226682)
