### PR TITLE
[DAS-Dashboard #1176] Implementation of the Query UI.

### DIFF
--- a/das-cli/src/commands/config/config_sections/atomdb.py
+++ b/das-cli/src/commands/config/config_sections/atomdb.py
@@ -139,7 +139,7 @@ def mongo_setup(settings: Settings, skip_cluster: bool) -> dict[str, Any]:
 
     return {
         "mongodb": {
-            "image": MONGODB_IMAGE_NAME + MONGODB_IMAGE_VERSION,
+            "image": f"{MONGODB_IMAGE_NAME}:{MONGODB_IMAGE_VERSION}",
             "endpoint": f"localhost:{mongodb_port}",
             "username": mongodb_username,
             "password": mongodb_password,

--- a/das-cli/src/common/config/core.py
+++ b/das-cli/src/common/config/core.py
@@ -12,7 +12,7 @@ def get_core_defaults_dict() -> Dict[str, Any]:
                 "nodes": [{"context": "default", "ip": "localhost", "username": "arturgontijo"}],
             },
             "mongodb": {
-                "image": "mongodb/mongodb-community-server:8.2-ubuntu2204",
+                "image": "mongodb/mongodb-community-server:8.0.4-ubuntu2204",
                 "endpoint": "localhost:40021",
                 "username": "admin",
                 "password": "admin",

--- a/das-cli/src/common/container_manager/atomdb/mongodb_container_manager.py
+++ b/das-cli/src/common/container_manager/atomdb/mongodb_container_manager.py
@@ -96,6 +96,8 @@ class MongodbContainerManager(ContainerManager):
                 "MaximumRetryCount": 5,
             },
             environment={
+                "MONGO_INITDB_ROOT_USERNAME": username,
+                "MONGO_INITDB_ROOT_PASSWORD": password,
                 "MONGODB_INITDB_ROOT_USERNAME": username,
                 "MONGODB_INITDB_ROOT_PASSWORD": password,
             },

--- a/das-cli/src/settings/config.py
+++ b/das-cli/src/settings/config.py
@@ -29,7 +29,7 @@ REDIS_IMAGE_NAME = "redis"
 REDIS_IMAGE_VERSION = "7.2.3-alpine"
 
 MONGODB_IMAGE_NAME = "mongodb/mongodb-community-server"
-MONGODB_IMAGE_VERSION = "8.2-ubuntu2204"
+MONGODB_IMAGE_VERSION = "8.0.4-ubuntu2204"
 
 METTA_PARSER_IMAGE_NAME = "trueagi/das"
 METTA_PARSER_IMAGE_VERSION = "1.0.0-metta-parser"

--- a/das-cli/tests/integration/fixtures/config/simple.json
+++ b/das-cli/tests/integration/fixtures/config/simple.json
@@ -2,7 +2,7 @@
   "atomdb": {
     "type": "redismongodb",
     "mongodb": {
-      "image": "mongodb/mongodb-community-server8.2-ubuntu2204",
+      "image": "mongodb/mongodb-community-server:8.0.4-ubuntu2204",
       "endpoint": "localhost:40021",
       "username": "admin",
       "password": "admin",

--- a/das-dashboard/backend/controllers/config_controllers.py
+++ b/das-dashboard/backend/controllers/config_controllers.py
@@ -57,7 +57,7 @@ async def get_config():
     return JSONResponse(
         status_code=200,
         content={
-            "content": WEB_CONFIG.config_dictionary
+            "content": WEB_CONFIG.require_config_dictionary()
         },
     )
 

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -4,6 +4,8 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from requests import Response
+
 from services_init import QUERY_SERVICES
 from shared.exceptions.custom_exceptions import CommandRouterConnectionError
 
@@ -91,7 +93,7 @@ async def get_execution_stream(websocket: WebSocket, execution_id: str):
         )
 
 
-def _proxy_json_content(response):
+def _proxy_json_content(response : Response):
     try:
         return response.json()
     except ValueError:

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -1,8 +1,21 @@
-from fastapi import APIRouter
+import json
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
 from services_init import QUERY_SERVICES
+from shared.exceptions.custom_exceptions import CommandRouterConnectionError
 
 router = APIRouter(prefix="/query", tags=["Query", "Query Agent"])
+
+TERMINAL_STATUSES = frozenset({"completed", "error", "aborted"})
+
+
+class QueryExecutionBody(BaseModel):
+    command_type: str
+    command_text: str
+
 
 @router.get("/ping")
 def proxy_health_check():
@@ -10,22 +23,76 @@ def proxy_health_check():
 
     return JSONResponse(
         status_code=response.status_code,
-        content=response.text
+        content=response.text,
     )
 
 
 @router.post("/executions")
-def create_execution_on_proxy():
-    pass
+def create_execution_on_proxy(body: QueryExecutionBody):
+    response = QUERY_SERVICES.execute_proxy_command(
+        body.command_type,
+        body.command_text,
+    )
 
-@router.get("/executions/{id}")
-def get_execution_status():
-    pass
+    return JSONResponse(
+        status_code=response.status_code,
+        content=_proxy_json_content(response),
+    )
 
-@router.post("/executions/{id}/cancel")
-def cancel_query_execution():
-    pass
 
-@router.websocket("/executions/{id}")
-def get_execution_stream():
-    pass
+@router.get("/executions/{execution_id}")
+def get_execution_status(execution_id: str):
+    response = QUERY_SERVICES.get_query_status(execution_id)
+
+    return JSONResponse(
+        status_code=response.status_code,
+        content=_proxy_json_content(response),
+    )
+
+
+@router.post("/executions/{execution_id}/cancel")
+def cancel_query_execution(execution_id: str):
+    response = QUERY_SERVICES.cancel_query_execution(execution_id)
+
+    return JSONResponse(
+        status_code=response.status_code,
+        content=_proxy_json_content(response),
+    )
+
+
+@router.websocket("/executions/{execution_id}")
+async def get_execution_stream(websocket: WebSocket, execution_id: str):
+    await websocket.accept()
+
+    try:
+        async for event in QUERY_SERVICES.stream_execution_events(execution_id):
+            await websocket.send_json(event)
+
+            status = event.get("status")
+            if status in TERMINAL_STATUSES:
+                break
+    except WebSocketDisconnect:
+        pass
+    except CommandRouterConnectionError as error:
+        await websocket.send_json(
+            {
+                "execution_id": execution_id,
+                "status": "error",
+                "message": error.message,
+            }
+        )
+    except json.JSONDecodeError:
+        await websocket.send_json(
+            {
+                "execution_id": execution_id,
+                "status": "error",
+                "message": "Invalid JSON received from the command router stream.",
+            }
+        )
+
+
+def _proxy_json_content(response):
+    try:
+        return response.json()
+    except ValueError:
+        return {"content": response.text}

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -9,15 +9,11 @@ from requests import Response
 from services_init import QUERY_SERVICES
 from shared.exceptions.custom_exceptions import CommandRouterConnectionError
 
+from shared.dtos.query_execution_dto import QueryExecutionDto
+
 router = APIRouter(prefix="/query", tags=["Query", "Query Agent"])
 
 TERMINAL_STATUSES = frozenset({"completed", "error", "aborted"})
-
-
-class QueryExecutionBody(BaseModel):
-    command_type: str
-    command_text: str
-
 
 @router.get("/ping")
 def proxy_health_check():
@@ -30,7 +26,7 @@ def proxy_health_check():
 
 
 @router.post("/executions")
-def create_execution_on_proxy(body: QueryExecutionBody):
+def create_execution_on_proxy(body: QueryExecutionDto):
     response = QUERY_SERVICES.execute_proxy_command(
         body.command_type,
         body.command_text,

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -1,10 +1,9 @@
 import json
+from contextlib import aclosing
+from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
-from fastapi.logger import logger
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
-
 from requests import Response
 
 from services_init import QUERY_SERVICES
@@ -31,7 +30,7 @@ def proxy_health_check():
 
     return JSONResponse(
         status_code=response.status_code,
-        content=response.text,
+        content=_proxy_json_content(response),
     )
 
 
@@ -90,33 +89,34 @@ async def get_execution_stream(websocket: WebSocket, execution_id: str):
     await websocket.accept()
 
     try:
-        async for event in QUERY_SERVICES.stream_execution_events(execution_id):
-            await websocket.send_json(event)
+        async with aclosing(QUERY_SERVICES.stream_execution_events(execution_id)) as stream:
+            async for event in stream:
+                await websocket.send_json(event)
 
-            status = event.get("status")
-            if status in TERMINAL_STATUSES:
-                break
+                if event.get("status") in TERMINAL_STATUSES:
+                    break
     except WebSocketDisconnect:
         pass
     except CommandRouterConnectionError as error:
-        await websocket.send_json(
-            {
-                "execution_id": execution_id,
-                "status": "error",
-                "message": error.message,
-            }
-        )
+        await _safe_send_error(websocket, execution_id, error.message)
     except json.JSONDecodeError:
-        await websocket.send_json(
-            {
-                "execution_id": execution_id,
-                "status": "error",
-                "message": "Invalid JSON received from the command router stream.",
-            }
+        await _safe_send_error(
+            websocket,
+            execution_id,
+            "Invalid JSON received from the command router stream.",
         )
 
 
-def _proxy_json_content(response : Response):
+async def _safe_send_error(websocket: WebSocket, execution_id: str, message: str) -> None:
+    try:
+        await websocket.send_json(
+            {"execution_id": execution_id, "status": "error", "message": message}
+        )
+    except (WebSocketDisconnect, RuntimeError):
+        pass
+
+
+def _proxy_json_content(response: Response) -> Any:
     try:
         return response.json()
     except ValueError:

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from services_init import QUERY_SERVICES
+
+router = APIRouter(prefix="/query", tags=["Query", "Query Agent"])
+
+@router.get("/ping")
+def proxy_health_check():
+    response = QUERY_SERVICES.health_check_proxy()
+
+    return JSONResponse(
+        status_code=response.status_code,
+        content=response.text
+    )
+
+
+@router.post("/executions")
+def create_execution_on_proxy():
+    pass
+
+@router.get("/executions/{id}")
+def get_execution_status():
+    pass
+
+@router.post("/executions/{id}/cancel")
+def cancel_query_execution():
+    pass
+
+@router.websocket("/executions/{id}")
+def get_execution_stream():
+    pass

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -16,14 +16,14 @@ router = APIRouter(prefix="/query", tags=["Query", "Query Agent"])
 
 TERMINAL_STATUSES = frozenset({"completed", "error", "aborted"})
 
+
 @router.get("/param/defaults")
 def get_param_defaults():
-    response = QUERY_SERVICES.get_default_params_from_config()
-
     return JSONResponse(
         status_code=200,
-        content=response
+        content=QUERY_SERVICES.get_default_params_from_config(),
     )
+
 
 @router.get("/ping")
 def proxy_health_check():

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -1,6 +1,7 @@
 import json
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from fastapi.logger import logger
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -41,10 +42,27 @@ def create_execution_on_proxy(body: QueryExecutionDto):
 @router.get("/executions/{execution_id}")
 def get_execution_status(execution_id: str):
     response = QUERY_SERVICES.get_query_status(execution_id)
-
+    content = _proxy_json_content(response)
+    
     return JSONResponse(
         status_code=response.status_code,
-        content=_proxy_json_content(response),
+        content=content,
+    )
+
+
+@router.get("/executions/{execution_id}/answers")
+def get_execution_answers(
+    execution_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1, le=100),
+):
+    return JSONResponse(
+        status_code=200,
+        content=QUERY_SERVICES.get_execution_answers(
+            execution_id,
+            page=page,
+            page_size=page_size,
+        ),
     )
 
 

--- a/das-dashboard/backend/controllers/query_controllers.py
+++ b/das-dashboard/backend/controllers/query_controllers.py
@@ -16,6 +16,15 @@ router = APIRouter(prefix="/query", tags=["Query", "Query Agent"])
 
 TERMINAL_STATUSES = frozenset({"completed", "error", "aborted"})
 
+@router.get("/param/defaults")
+def get_param_defaults():
+    response = QUERY_SERVICES.get_default_params_from_config()
+
+    return JSONResponse(
+        status_code=200,
+        content=response
+    )
+
 @router.get("/ping")
 def proxy_health_check():
     response = QUERY_SERVICES.health_check_proxy()

--- a/das-dashboard/backend/main.py
+++ b/das-dashboard/backend/main.py
@@ -8,6 +8,7 @@ from shared.exceptions.exception_handlers import AppExceptionHandlers
 from shared.internal.constants import CONFIG_PATH
 from shared.utils.das_cli_config import set_das_cli_config
 from shared.utils.storage_check import validate_persistent_storage
+from shared.db.init_db import init_db
 from services_init import WEB_CONFIG, WORKSPACE_SERVICES
 
 # Controllers
@@ -23,6 +24,7 @@ from controllers.query_controllers import router as query_router
 async def lifespan(app: FastAPI):
     validate_persistent_storage()
     WORKSPACE_SERVICES.ensure_workspace()
+    init_db()
     WEB_CONFIG.load_user_profile()
     WEB_CONFIG.load_config_dictionary()
 

--- a/das-dashboard/backend/main.py
+++ b/das-dashboard/backend/main.py
@@ -16,6 +16,7 @@ from controllers.container_controllers import router as container_router
 from controllers.profile_controllers import router as profile_router
 from controllers.config_controllers import router as config_router
 from controllers.metrics_controllers import router as metrics_router
+from controllers.query_controllers import router as query_router
 
 
 @asynccontextmanager
@@ -56,3 +57,4 @@ dashboard_app.include_router(container_router)
 dashboard_app.include_router(profile_router)
 dashboard_app.include_router(config_router)
 dashboard_app.include_router(metrics_router)
+dashboard_app.include_router(query_router)

--- a/das-dashboard/backend/main.py
+++ b/das-dashboard/backend/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.logger import logger
 
 from shared.exceptions.exception_handlers import AppExceptionHandlers
+from shared.exceptions.custom_exceptions import ConfigurationFileLoadError
 from shared.internal.constants import CONFIG_PATH
 from shared.utils.das_cli_config import set_das_cli_config
 from shared.utils.storage_check import validate_persistent_storage
@@ -26,7 +27,10 @@ async def lifespan(app: FastAPI):
     WORKSPACE_SERVICES.ensure_workspace()
     init_db()
     WEB_CONFIG.load_user_profile()
-    WEB_CONFIG.load_config_dictionary()
+    try:
+        WEB_CONFIG.load_config_dictionary(required=False)
+    except ConfigurationFileLoadError as error:
+        logger.info("Configuration not loaded at startup: %s", error)
 
     if os.path.exists(CONFIG_PATH):
         try:

--- a/das-dashboard/backend/requirements.txt
+++ b/das-dashboard/backend/requirements.txt
@@ -14,6 +14,7 @@ starlette==1.0.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 uvicorn==0.46.0
+requests==2.32.5
 uvloop==0.22.1
 watchfiles==1.1.1
 websockets==16.0

--- a/das-dashboard/backend/services/config_services.py
+++ b/das-dashboard/backend/services/config_services.py
@@ -11,6 +11,7 @@ from shared.internal.web_configuration import WebConfiguration
 from shared.mappers.das_config_mapper import ConfigMapper
 from shared.mappers.nested_config_mapper import NestedConfigMapper
 from shared.builders.atom_db_builder import AtomDbBuilder
+from shared.exceptions.custom_exceptions import ConfigurationFileLoadError
 from shared.utils.adapter_context_mapping import save_context_mapping_content
 from shared.utils.das_cli_config import set_das_cli_config
 from shared.utils.flat_config_utils import merge_flat_config
@@ -34,7 +35,9 @@ class ConfigServices:
         AtomDbBuilder.apply_profile_usernames(nested_config, profile_username)
 
         await run_in_threadpool(self._persist_config, nested_config)
-        await run_in_threadpool(self.web_config.load_config_dictionary)
+        await run_in_threadpool(
+            lambda: self.web_config.load_config_dictionary(nested_config)
+        )
         await run_in_threadpool(
             set_das_cli_config,
             CONFIG_PATH,
@@ -56,7 +59,7 @@ class ConfigServices:
         }
 
     async def _propagate_config_to_remotes(self, nested_config: dict) -> list[str]:
-        targets = self.web_config.map_hosts_from_config(nested_config)
+        targets = self.web_config.map_remote_hosts()
         remote_hosts: list[str] = []
 
         for target in targets:
@@ -98,14 +101,18 @@ class ConfigServices:
 
     async def load_config(self, nested_config: dict) -> dict:
         if not isinstance(nested_config, dict):
-            raise ValueError("Configuration must be a JSON object.")
+            raise ConfigurationFileLoadError("Configuration must be a JSON object.")
 
         if "atomdb" not in nested_config or "agents" not in nested_config:
-            raise ValueError("Configuration must include 'atomdb' and 'agents' sections.")
+            raise ConfigurationFileLoadError(
+                "Configuration must include 'atomdb' and 'agents' sections."
+            )
 
         await run_in_threadpool(self._persist_config, nested_config)
         flat = merge_flat_config(NestedConfigMapper.to_flat(nested_config), CONSTANTS)
-        await run_in_threadpool(self.web_config.load_config_dictionary)
+        await run_in_threadpool(
+            lambda: self.web_config.load_config_dictionary(nested_config)
+        )
         await run_in_threadpool(
             set_das_cli_config,
             CONFIG_PATH,
@@ -131,8 +138,10 @@ class ConfigServices:
                 if isinstance(nested, dict):
                     saved_flat = NestedConfigMapper.to_flat(nested)
                     flat = merge_flat_config(saved_flat, CONSTANTS)
-            except (OSError, json.JSONDecodeError, TypeError, ValueError, IndexError):
-                pass
+            except (OSError, json.JSONDecodeError, TypeError, ValueError, IndexError) as error:
+                raise ConfigurationFileLoadError(
+                    f"Could not load saved configuration defaults: {error}"
+                ) from error
 
         return self._defaults_response(flat)
 

--- a/das-dashboard/backend/services/config_services.py
+++ b/das-dashboard/backend/services/config_services.py
@@ -100,13 +100,7 @@ class ConfigServices:
                 ssh.close()
 
     async def load_config(self, nested_config: dict) -> dict:
-        if not isinstance(nested_config, dict):
-            raise ConfigurationFileLoadError("Configuration must be a JSON object.")
-
-        if "atomdb" not in nested_config or "agents" not in nested_config:
-            raise ConfigurationFileLoadError(
-                "Configuration must include 'atomdb' and 'agents' sections."
-            )
+        self.web_config._validate_nested_config(nested_config)
 
         await run_in_threadpool(self._persist_config, nested_config)
         flat = merge_flat_config(NestedConfigMapper.to_flat(nested_config), CONSTANTS)

--- a/das-dashboard/backend/services/container_services.py
+++ b/das-dashboard/backend/services/container_services.py
@@ -9,8 +9,9 @@ from shared.enums.das_services import DASServices
 from shared.internal.web_configuration import WebConfiguration
 from shared.internal.constants import DEFAULT_SSHKEY_CLONE_PATH, LOCAL_HOSTS
 from shared.exceptions.custom_exceptions import (
+    ConfigurationFileLoadError,
+    ConfigurationValueNotFoundError,
     DasCliCommandException,
-    DASServiceInstantiationError,
     DASCLIResponseDecodeError,
 )
 
@@ -65,22 +66,19 @@ class ContainerServices:
         has_local_command = False
 
         for cmd_name in ordered_services:
-            if cmd_name not in self.web_config.config_dictionary:
-                continue
-
             try:
                 service = DASServices.from_command(cmd_name)
                 host = self._resolve_service_host(service)
+            except ConfigurationValueNotFoundError:
+                continue
 
+            try:
                 if not self._is_remote(host):
                     has_local_command = True
 
                 commands_to_run[cmd_name] = self.build_das_cli_command(
                     host=host, service=service, action=action.value
                 )
-
-            except DASServiceInstantiationError as exc:
-                raise ValueError(f"Service '{cmd_name}' is not configured.") from exc
             except ValueError as exc:
                 raise ValueError(f"Unknown service: '{cmd_name}'") from exc
 
@@ -270,14 +268,11 @@ class ContainerServices:
 
     def _resolve_service_host(self, service: DASServices) -> str:
         command = service.value["command"]
-        service_config = self.web_config.config_dictionary.get(command)
-
-        if not service_config:
-            raise DASServiceInstantiationError()
+        service_config = self.web_config.get_service_config(command)
         return service_config["host"]
 
     def _resolve_query_peer(self):
-        query = self.web_config.config_dictionary.get("query-agent")
+        query = self.web_config.get_service_config("query-agent", required=False)
         if not query:
             return None
         return {

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -6,6 +6,7 @@ import requests
 from requests import Response
 from requests.exceptions import RequestException
 from websockets.asyncio.client import connect
+from websockets.exceptions import WebSocketException
 
 from shared.db import query_db
 from shared.exceptions.custom_exceptions import CommandRouterConnectionError, CustomValueError
@@ -39,7 +40,7 @@ class QueryServices:
                     if payload.get("type") == "chunk":
                         query_db.save_answers_from_chunk(execution_id, payload)
                     yield payload
-        except RequestException as error:
+        except (WebSocketException, RequestException) as error:
             raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
         except OSError as error:
             raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
@@ -76,7 +77,11 @@ class QueryServices:
         return self._post_execution(command_type, command_text)
 
     def _set_query_parameters(self, command_type: str, command_text: str) -> Response:
-        custom_parameters_dict = json.loads(command_text)
+        try:
+            custom_parameters_dict = json.loads(command_text)
+        except json.JSONDecodeError as error:
+            raise CustomValueError(f"Invalid query parameters payload: {error}") from error
+
         if not custom_parameters_dict:
             raise CustomValueError("No query parameters were provided.")
 

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -1,0 +1,106 @@
+import json
+
+import requests
+from fastapi.logger import logger
+from requests import Response
+from requests.exceptions import RequestException
+from websockets.asyncio.client import connect
+
+from shared.exceptions.custom_exceptions import CommandRouterConnectionError, CustomValueError
+from shared.internal.constants import LOCAL_HOSTS
+from shared.internal.web_configuration import WebConfiguration
+
+VALID_COMMAND_TYPES = ("get", "set", "query")  # Evolution will be disconsidered for now.
+
+
+class QueryServices:
+
+    def __init__(self, web_config: WebConfiguration):
+        self.web_config = web_config
+
+    def health_check_proxy(self) -> Response:
+        return self._call_http_proxy("GET", "/ping")
+
+    def get_query_websocket_data(self, execution_id: str):
+        try:
+            command_proxy_url = self._find_command_router_http_url()
+            connect(
+                uri=f"ws://{command_proxy_url}/executions/{execution_id}",
+                open_timeout=10,
+                close_timeout=5,
+            )
+        except RequestException:
+            pass
+
+    def get_query_status(self, execution_id: str) -> Response:
+        return self._call_http_proxy("GET", f"/executions/{execution_id}")
+
+    def cancel_query_execution(self, execution_id: str) -> Response:
+        return self._call_http_proxy("GET", f"/executions/{execution_id}/cancel")
+
+    def execute_proxy_command(self, command_type: str, command_text: str) -> Response:
+        handlers = {
+            "get": self._get_query_parameters,
+            "set": self._set_query_parameters,
+            "query": self._create_query_execution,
+        }
+
+        if command_type not in VALID_COMMAND_TYPES:
+            raise CustomValueError(
+                "This proxy command does not exist/is not permitted in the current context."
+            )
+
+        return handlers[command_type](command_type, command_text)
+
+    def _get_query_parameters(self, command_type: str, command_text: str) -> Response:
+        return self._call_http_proxy(
+            "POST",
+            "/executions",
+            data={"command_type": command_type, "command_text": command_text},
+        )
+
+    def _set_query_parameters(self, command_type: str, command_text: str) -> Response:
+        custom_parameters_dict = json.loads(command_text)
+        response = None
+
+        for key, value in custom_parameters_dict.items():
+            response = self._call_http_proxy(
+                "POST",
+                "/executions",
+                data={"command_type": command_type, "command_text": f"param {key} {value}"},
+            )
+
+        return response
+
+    def _create_query_execution(self, command_type: str, command_text: str) -> Response:
+        return self._call_http_proxy(
+            "POST",
+            "/executions",
+            data={"command_type": command_type, "command_text": command_text},
+        )
+
+    def _call_http_proxy(self, method: str, path: str, **request_kwargs) -> Response:
+        command_proxy_url = self._find_command_router_http_url()
+        url = f"http://{command_proxy_url}{path}"
+
+        try:
+            return requests.request(method, url, timeout=5, **request_kwargs)
+        except RequestException as error:
+            raise CommandRouterConnectionError(endpoint=url, detail=str(error)) from error
+
+    def _find_command_router_http_url(self) -> str:
+        HTTP_PROXY_PORT = 40009
+        service_host_map = self.web_config.config_dictionary
+
+        try:
+            router_host = service_host_map.get("command-router", None).get("host")
+
+            if router_host is None:
+                raise KeyError
+
+            connect_host = "localhost" if router_host in LOCAL_HOSTS else router_host
+            return f"{connect_host}:{HTTP_PROXY_PORT}"
+
+        except (AttributeError, KeyError):
+            logger.critical("Command Router not found in service/host map.")
+            raise

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -3,7 +3,6 @@ from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
-from fastapi.logger import logger
 from requests import Response
 from requests.exceptions import RequestException
 from websockets.asyncio.client import connect
@@ -106,6 +105,9 @@ class QueryServices:
 
         return responses[-1]
 
+    def get_default_params_from_config():
+        pass
+
     @staticmethod
     def _format_param_value(value) -> str:
         if isinstance(value, bool):
@@ -133,20 +135,10 @@ class QueryServices:
 
     def _find_command_router_http_url(self) -> str:
         HTTP_PROXY_PORT = 40009
-        service_host_map = self.web_config.config_dictionary
-
-        try:
-            router_host = service_host_map.get("command-router", None).get("host")
-
-            if router_host is None:
-                raise KeyError
-
-            connect_host = "localhost" if router_host in LOCAL_HOSTS else router_host
-            return f"{connect_host}:{HTTP_PROXY_PORT}"
-
-        except (AttributeError, KeyError):
-            logger.critical("Command Router not found in service/host map.")
-            raise
+        router = self.web_config.get_service_config("command-router")
+        router_host = router["host"]
+        connect_host = "localhost" if router_host in LOCAL_HOSTS else router_host
+        return f"{connect_host}:{HTTP_PROXY_PORT}"
 
     def _build_websocket_url(self, execution_id: str) -> str:
         return f"ws://{self._find_command_router_http_url()}{ROUTE_PREFIX}/ws/{execution_id}"

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -1,4 +1,6 @@
+import os
 import json
+from collections.abc import AsyncIterator
 
 import requests
 from fastapi.logger import logger
@@ -6,6 +8,7 @@ from requests import Response
 from requests.exceptions import RequestException
 from websockets.asyncio.client import connect
 
+from shared.db import query_db
 from shared.exceptions.custom_exceptions import CommandRouterConnectionError, CustomValueError
 from shared.internal.constants import LOCAL_HOSTS
 from shared.internal.web_configuration import WebConfiguration
@@ -21,22 +24,29 @@ class QueryServices:
     def health_check_proxy(self) -> Response:
         return self._call_http_proxy("GET", "/ping")
 
-    def get_query_websocket_data(self, execution_id: str):
+    async def stream_execution_events(self, execution_id: str) -> AsyncIterator[dict]:
+        websocket_url = self._build_websocket_url(execution_id)
+
         try:
-            command_proxy_url = self._find_command_router_http_url()
-            connect(
-                uri=f"ws://{command_proxy_url}/executions/{execution_id}",
+            async with connect(
+                websocket_url,
                 open_timeout=10,
                 close_timeout=5,
-            )
-        except RequestException:
-            pass
+            ) as upstream:
+                async for message in upstream:
+                    payload = json.loads(message)
+                    query_db.save_event(execution_id, payload)
+                    yield payload
+        except RequestException as error:
+            raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
+        except OSError as error:
+            raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
 
     def get_query_status(self, execution_id: str) -> Response:
         return self._call_http_proxy("GET", f"/executions/{execution_id}")
 
     def cancel_query_execution(self, execution_id: str) -> Response:
-        return self._call_http_proxy("GET", f"/executions/{execution_id}/cancel")
+        return self._call_http_proxy("POST", f"/executions/{execution_id}/cancel")
 
     def execute_proxy_command(self, command_type: str, command_text: str) -> Response:
         handlers = {
@@ -104,3 +114,6 @@ class QueryServices:
         except (AttributeError, KeyError):
             logger.critical("Command Router not found in service/host map.")
             raise
+
+    def _build_websocket_url(self, execution_id: str) -> str:
+        return f"ws://{self._find_command_router_http_url()}/executions/{execution_id}"

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import AsyncIterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
 from fastapi.logger import logger
@@ -11,6 +12,7 @@ from shared.db import query_db
 from shared.exceptions.custom_exceptions import CommandRouterConnectionError, CustomValueError
 from shared.internal.constants import LOCAL_HOSTS
 from shared.internal.web_configuration import WebConfiguration
+from shared.utils.parse_query_answer import transform_stream_event
 
 VALID_COMMAND_TYPES = ("get", "set", "query")  # Evolution will be disconsidered for now.
 ROUTE_PREFIX = "/command-router"
@@ -33,8 +35,10 @@ class QueryServices:
                 close_timeout=5,
             ) as upstream:
                 async for message in upstream:
-                    payload = json.loads(message)
+                    payload = transform_stream_event(json.loads(message))
                     query_db.save_event(execution_id, payload)
+                    if payload.get("type") == "chunk":
+                        query_db.save_answers_from_chunk(execution_id, payload)
                     yield payload
         except RequestException as error:
             raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
@@ -43,6 +47,14 @@ class QueryServices:
 
     def get_query_status(self, execution_id: str) -> Response:
         return self._call_http_proxy("GET", f"{ROUTE_PREFIX}/executions/{execution_id}")
+
+    def get_execution_answers(
+        self,
+        execution_id: str,
+        page: int = 1,
+        page_size: int = 10,
+    ) -> dict:
+        return query_db.get_answers_page(execution_id, page, page_size)
 
     def cancel_query_execution(self, execution_id: str) -> Response:
         return self._call_http_proxy("POST", f"{ROUTE_PREFIX}/executions/{execution_id}/cancel")
@@ -66,15 +78,33 @@ class QueryServices:
 
     def _set_query_parameters(self, command_type: str, command_text: str) -> Response:
         custom_parameters_dict = json.loads(command_text)
-        response = None
+        if not custom_parameters_dict:
+            raise CustomValueError("No query parameters were provided.")
 
-        for key, value in custom_parameters_dict.items():
-            response = self._post_execution(
-                command_type,
-                f"param {key} {self._format_param_value(value)}",
-            )
+        responses = []
+        max_workers = min(len(custom_parameters_dict), 8)
 
-        return response
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [
+                executor.submit(
+                    self._post_execution,
+                    command_type,
+                    f"param {key} {self._format_param_value(value)}",
+                )
+                for key, value in custom_parameters_dict.items()
+            ]
+
+            for future in as_completed(futures):
+                responses.append(future.result())
+
+        failed_response = next(
+            (response for response in responses if response.status_code >= 400),
+            None,
+        )
+        if failed_response is not None:
+            return failed_response
+
+        return responses[-1]
 
     @staticmethod
     def _format_param_value(value) -> str:

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -1,4 +1,3 @@
-import os
 import json
 from collections.abc import AsyncIterator
 
@@ -14,7 +13,7 @@ from shared.internal.constants import LOCAL_HOSTS
 from shared.internal.web_configuration import WebConfiguration
 
 VALID_COMMAND_TYPES = ("get", "set", "query")  # Evolution will be disconsidered for now.
-
+ROUTE_PREFIX = "/command-router"
 
 class QueryServices:
 
@@ -43,10 +42,10 @@ class QueryServices:
             raise CommandRouterConnectionError(endpoint=websocket_url, detail=str(error)) from error
 
     def get_query_status(self, execution_id: str) -> Response:
-        return self._call_http_proxy("GET", f"/executions/{execution_id}")
+        return self._call_http_proxy("GET", f"{ROUTE_PREFIX}/executions/{execution_id}")
 
     def cancel_query_execution(self, execution_id: str) -> Response:
-        return self._call_http_proxy("POST", f"/executions/{execution_id}/cancel")
+        return self._call_http_proxy("POST", f"{ROUTE_PREFIX}/executions/{execution_id}/cancel")
 
     def execute_proxy_command(self, command_type: str, command_text: str) -> Response:
         handlers = {
@@ -63,30 +62,28 @@ class QueryServices:
         return handlers[command_type](command_type, command_text)
 
     def _get_query_parameters(self, command_type: str, command_text: str) -> Response:
-        return self._call_http_proxy(
-            "POST",
-            "/executions",
-            data={"command_type": command_type, "command_text": command_text},
-        )
+        return self._post_execution(command_type, command_text)
 
     def _set_query_parameters(self, command_type: str, command_text: str) -> Response:
         custom_parameters_dict = json.loads(command_text)
         response = None
 
         for key, value in custom_parameters_dict.items():
-            response = self._call_http_proxy(
-                "POST",
-                "/executions",
-                data={"command_type": command_type, "command_text": f"param {key} {value}"},
+            response = self._post_execution(
+                command_type,
+                f"param {key} {value}",
             )
 
         return response
 
     def _create_query_execution(self, command_type: str, command_text: str) -> Response:
+        return self._post_execution(command_type, command_text)
+
+    def _post_execution(self, command_type: str, command_text: str) -> Response:
         return self._call_http_proxy(
             "POST",
-            "/executions",
-            data={"command_type": command_type, "command_text": command_text},
+            f"{ROUTE_PREFIX}/executions",
+            json={"command_type": command_type, "command_text": command_text},
         )
 
     def _call_http_proxy(self, method: str, path: str, **request_kwargs) -> Response:
@@ -116,4 +113,4 @@ class QueryServices:
             raise
 
     def _build_websocket_url(self, execution_id: str) -> str:
-        return f"ws://{self._find_command_router_http_url()}/executions/{execution_id}"
+        return f"ws://{self._find_command_router_http_url()}{ROUTE_PREFIX}/ws/{execution_id}"

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -105,8 +105,21 @@ class QueryServices:
 
         return responses[-1]
 
-    def get_default_params_from_config():
-        pass
+    def get_default_params_from_config(self) -> dict:
+        config = self.web_config.load_raw_configuration()
+        agents = config.get("agents") or {}
+
+        defaults = dict(agents.get("base_query", {}).get("params", {}))
+
+        query = dict(agents.get("query") or {})
+        query.pop("endpoint", None)
+        query.pop("ports_range", None)
+
+        query_params = query.get("params") or {}
+        if isinstance(query_params, dict):
+            defaults.update(query_params)
+
+        return defaults
 
     @staticmethod
     def _format_param_value(value) -> str:

--- a/das-dashboard/backend/services/query_services.py
+++ b/das-dashboard/backend/services/query_services.py
@@ -71,10 +71,16 @@ class QueryServices:
         for key, value in custom_parameters_dict.items():
             response = self._post_execution(
                 command_type,
-                f"param {key} {value}",
+                f"param {key} {self._format_param_value(value)}",
             )
 
         return response
+
+    @staticmethod
+    def _format_param_value(value) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
 
     def _create_query_execution(self, command_type: str, command_text: str) -> Response:
         return self._post_execution(command_type, command_text)

--- a/das-dashboard/backend/services_init.py
+++ b/das-dashboard/backend/services_init.py
@@ -5,6 +5,7 @@ from services.metrics_services import MetricsServices
 from services.config_services import ConfigServices
 from services.database_services import DatabaseServices
 from services.workspace_services import WorkspaceServices
+from services.query_services import QueryServices
 
 WEB_CONFIG = WebConfiguration()
 
@@ -13,4 +14,5 @@ DATABASE_SERVICES = DatabaseServices(WEB_CONFIG)
 PROFILE_SERVICES = ProfileServices(WEB_CONFIG)
 METRICS_SERVICES = MetricsServices(WEB_CONFIG)
 CONFIG_SERVICES = ConfigServices(WEB_CONFIG)
+QUERY_SERVICES = QueryServices(WEB_CONFIG)
 WORKSPACE_SERVICES = WorkspaceServices()

--- a/das-dashboard/backend/shared/builders/atom_db_builder.py
+++ b/das-dashboard/backend/shared/builders/atom_db_builder.py
@@ -5,7 +5,7 @@ from shared.utils.adapter_context_mapping import validate_context_mapping_path
 class AtomDbBuilder:
 
     REDIS_IMAGE = "redis:7.2.3-alpine"
-    MONGO_IMAGE = "mongodb/mongodb-community-server:8.2-ubuntu2204"
+    MONGO_IMAGE = "mongodb/mongodb-community-server:8.0.4-ubuntu2204"
     MORK_IMAGE = "trueagi/das:mork-server-1.0.4"
 
     _REDIS_MONGO_FIELDS = (

--- a/das-dashboard/backend/shared/db/init_db.py
+++ b/das-dashboard/backend/shared/db/init_db.py
@@ -1,0 +1,50 @@
+import os
+import sqlite3
+
+from shared.internal.constants import QUERY_DB_PATH
+
+QUERY_EVENT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS query_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id TEXT NOT NULL,
+    event_type TEXT,
+    status TEXT,
+    seq INTEGER,
+    received_count INTEGER,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_events_execution_id
+    ON query_events(execution_id);
+"""
+
+QUERY_ANSWER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS query_answers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    execution_id TEXT NOT NULL,
+    seq INTEGER,
+    answer_index INTEGER NOT NULL,
+    answer_text TEXT NOT NULL,
+    strength REAL NOT NULL,
+    importance REAL NOT NULL,
+    assignment_label TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_answers_execution_id
+    ON query_answers(execution_id);
+"""
+
+SCHEMAS = (
+    QUERY_EVENT_SCHEMA,
+    QUERY_ANSWER_SCHEMA,
+)
+
+
+def init_db() -> None:
+    os.makedirs(os.path.dirname(QUERY_DB_PATH), exist_ok=True)
+
+    with sqlite3.connect(QUERY_DB_PATH) as connection:
+        for schema in SCHEMAS:
+            connection.executescript(schema)

--- a/das-dashboard/backend/shared/db/query_db.py
+++ b/das-dashboard/backend/shared/db/query_db.py
@@ -45,6 +45,7 @@ def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
     created_at = datetime.now(timezone.utc).isoformat()
 
     with sqlite3.connect(QUERY_DB_PATH) as connection:
+        connection.execute("BEGIN IMMEDIATE")
         next_index = _next_answer_index(connection, execution_id)
         rows = []
 
@@ -58,8 +59,8 @@ def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
                     seq,
                     next_index,
                     json.dumps(item),
-                    float(item.get("strength", 0.0)),
-                    float(item.get("importance", 0.0)),
+                    float(item.get("strength") or 0.0),
+                    float(item.get("importance") or 0.0),
                     None,
                     created_at,
                 )
@@ -67,6 +68,7 @@ def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
             next_index += 1
 
         if not rows:
+            connection.rollback()
             return
 
         connection.executemany(
@@ -117,8 +119,8 @@ def get_answers_page(
         "total_pages": total_pages,
         "items": [
             {
-                "id": row[0],
                 **json.loads(row[1]),
+                "id": row[0],
             }
             for row in rows
         ],

--- a/das-dashboard/backend/shared/db/query_db.py
+++ b/das-dashboard/backend/shared/db/query_db.py
@@ -1,0 +1,28 @@
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from shared.internal.constants import QUERY_DB_PATH
+
+
+def save_event(execution_id: str, payload: dict) -> None:
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    with sqlite3.connect(QUERY_DB_PATH) as connection:
+        connection.execute(
+            """
+            INSERT INTO query_events (
+                execution_id, event_type, status, seq, received_count, payload_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                execution_id,
+                payload.get("type"),
+                payload.get("status"),
+                payload.get("seq"),
+                payload.get("received_count"),
+                json.dumps(payload),
+                created_at,
+            ),
+        )
+        connection.commit()

--- a/das-dashboard/backend/shared/db/query_db.py
+++ b/das-dashboard/backend/shared/db/query_db.py
@@ -5,6 +5,14 @@ from datetime import datetime, timezone
 from shared.internal.constants import QUERY_DB_PATH
 
 
+def _next_answer_index(connection: sqlite3.Connection, execution_id: str) -> int:
+    cursor = connection.execute(
+        "SELECT COALESCE(MAX(answer_index), -1) FROM query_answers WHERE execution_id = ?",
+        (execution_id,),
+    )
+    return cursor.fetchone()[0] + 1
+
+
 def save_event(execution_id: str, payload: dict) -> None:
     created_at = datetime.now(timezone.utc).isoformat()
 
@@ -26,3 +34,93 @@ def save_event(execution_id: str, payload: dict) -> None:
             ),
         )
         connection.commit()
+
+
+def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
+    data = payload.get("data")
+    if not isinstance(data, list) or not data:
+        return
+
+    seq = payload.get("seq")
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    with sqlite3.connect(QUERY_DB_PATH) as connection:
+        next_index = _next_answer_index(connection, execution_id)
+        rows = []
+
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+
+            rows.append(
+                (
+                    execution_id,
+                    seq,
+                    next_index,
+                    str(item.get("response", "")),
+                    0.0,
+                    float(item.get("importance", 0.0)),
+                    None,
+                    created_at,
+                )
+            )
+            next_index += 1
+
+        if not rows:
+            return
+
+        connection.executemany(
+            """
+            INSERT INTO query_answers (
+                execution_id, seq, answer_index, answer_text, strength, importance,
+                assignment_label, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        connection.commit()
+
+
+def get_answers_page(
+    execution_id: str,
+    page: int = 1,
+    page_size: int = 10,
+) -> dict:
+    page = max(1, page)
+    page_size = min(max(1, page_size), 100)
+    offset = (page - 1) * page_size
+
+    with sqlite3.connect(QUERY_DB_PATH) as connection:
+        total = connection.execute(
+            "SELECT COUNT(*) FROM query_answers WHERE execution_id = ?",
+            (execution_id,),
+        ).fetchone()[0]
+
+        rows = connection.execute(
+            """
+            SELECT answer_index, answer_text, importance
+            FROM query_answers
+            WHERE execution_id = ?
+            ORDER BY answer_index ASC
+            LIMIT ? OFFSET ?
+            """,
+            (execution_id, page_size, offset),
+        ).fetchall()
+
+    total_pages = (total + page_size - 1) // page_size if total else 0
+
+    return {
+        "execution_id": execution_id,
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "total_pages": total_pages,
+        "items": [
+            {
+                "id": row[0],
+                "response": row[1],
+                "importance": row[2],
+            }
+            for row in rows
+        ],
+    }

--- a/das-dashboard/backend/shared/db/query_db.py
+++ b/das-dashboard/backend/shared/db/query_db.py
@@ -49,7 +49,7 @@ def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
         rows = []
 
         for item in data:
-            if not isinstance(item, dict):
+            if not isinstance(item, dict) or item.get("count_only"):
                 continue
 
             rows.append(
@@ -57,8 +57,8 @@ def save_answers_from_chunk(execution_id: str, payload: dict) -> None:
                     execution_id,
                     seq,
                     next_index,
-                    str(item.get("response", "")),
-                    0.0,
+                    json.dumps(item),
+                    float(item.get("strength", 0.0)),
                     float(item.get("importance", 0.0)),
                     None,
                     created_at,
@@ -118,7 +118,7 @@ def get_answers_page(
         "items": [
             {
                 "id": row[0],
-                "response": row[1],
+                **json.loads(row[1]),
                 "importance": row[2],
             }
             for row in rows

--- a/das-dashboard/backend/shared/db/query_db.py
+++ b/das-dashboard/backend/shared/db/query_db.py
@@ -98,7 +98,7 @@ def get_answers_page(
 
         rows = connection.execute(
             """
-            SELECT answer_index, answer_text, importance
+            SELECT answer_index, answer_text
             FROM query_answers
             WHERE execution_id = ?
             ORDER BY answer_index ASC
@@ -119,7 +119,6 @@ def get_answers_page(
             {
                 "id": row[0],
                 **json.loads(row[1]),
-                "importance": row[2],
             }
             for row in rows
         ],

--- a/das-dashboard/backend/shared/dtos/query_execution_dto.py
+++ b/das-dashboard/backend/shared/dtos/query_execution_dto.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class QueryExecutionDto(BaseModel):
+    command_type: str
+    command_text: str

--- a/das-dashboard/backend/shared/exceptions/custom_exceptions.py
+++ b/das-dashboard/backend/shared/exceptions/custom_exceptions.py
@@ -109,6 +109,38 @@ class DASCLIResponseDecodeError(Exception):
     def __str__(self) -> str:
         return self.detail or self.message
 
+class ConfigurationFileLoadError(Exception):
+
+    def __init__(self, detail: str = ""):
+        base_message = (
+            "The DAS configuration file could not be loaded from the specified path. "
+            "Please set-up services and endpoints at the configuration page."
+        )
+        self.detail = detail.strip()
+        self.message = f"{base_message} {self.detail}".strip() if self.detail else base_message
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ConfigurationValueNotFoundError(Exception):
+
+    def __init__(self, key: str = ""):
+        base_message = (
+            "Could not find specified section/value from configuration file. "
+            "Please try setting up any missing services and endpoints at the configuration page."
+        )
+        self.key = key.strip()
+        self.message = (
+            f"{base_message} Missing: '{self.key}'."
+            if self.key
+            else base_message
+        )
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return self.message
 
 class CommandRouterConnectionError(Exception):
 

--- a/das-dashboard/backend/shared/exceptions/custom_exceptions.py
+++ b/das-dashboard/backend/shared/exceptions/custom_exceptions.py
@@ -108,3 +108,15 @@ class DASCLIResponseDecodeError(Exception):
 
     def __str__(self) -> str:
         return self.detail or self.message
+
+
+class CommandRouterConnectionError(Exception):
+
+    def __init__(self, endpoint: str, detail: str = ""):
+        self.endpoint = endpoint
+        self.message = f"Could not reach the Command Router HTTP API at {endpoint}."
+        self.detail = detail
+        super().__init__(self.detail or self.message)
+
+    def __str__(self) -> str:
+        return self.detail or self.message

--- a/das-dashboard/backend/shared/exceptions/exception_handlers.py
+++ b/das-dashboard/backend/shared/exceptions/exception_handlers.py
@@ -10,7 +10,8 @@ from .custom_exceptions import (
     DASCLIResponseDecodeError,
     RemoteSshConnectionError,
     RemoteSshTransferError,
-    CustomValueError
+    CustomValueError,
+    CommandRouterConnectionError,
 )
 
 
@@ -61,6 +62,11 @@ class AppExceptionHandlers:
         app.add_exception_handler(
             CustomValueError,
             self.handle_custom_value_error,
+        )
+
+        app.add_exception_handler(
+            CommandRouterConnectionError,
+            self.handle_command_router_connection_error,
         )
 
     async def handle_das_cli_command_error(
@@ -148,15 +154,29 @@ class AppExceptionHandlers:
 
         return JSONResponse(status_code=400, content=content)
     
+    async def handle_command_router_connection_error(
+        self,
+        request: Request,
+        exc: CommandRouterConnectionError,
+    ):
+        content = {"message": exc.message, "endpoint": exc.endpoint}
+        if exc.detail:
+            content["exceptionMessage"] = exc.detail
+
+        return JSONResponse(status_code=502, content=content)
+
     async def handle_general_exception(
         self,
         request: Request,
         exc: Exception
     ):
         error_message = getattr(exc, "message", None)
-        
+
         if not error_message:
-            error_message = exc.args[0] if exc.args else str(exc) or "An unexpected internal server error occurred."
+            if exc.args:
+                error_message = str(exc.args[0])
+            else:
+                error_message = str(exc) or "An unexpected internal server error occurred."
 
         return JSONResponse(
             status_code=500,

--- a/das-dashboard/backend/shared/exceptions/exception_handlers.py
+++ b/das-dashboard/backend/shared/exceptions/exception_handlers.py
@@ -12,62 +12,34 @@ from .custom_exceptions import (
     RemoteSshTransferError,
     CustomValueError,
     CommandRouterConnectionError,
+    ConfigurationFileLoadError,
+    ConfigurationValueNotFoundError,
+    
 )
-
 
 class AppExceptionHandlers:
 
     def __init__(self, app: FastAPI):
 
-        app.add_exception_handler(
-            DasCliCommandException,
-            self.handle_das_cli_command_error
-        )
+        CUSTOM_EXCEPTIONS = [
+            (Exception, self.handle_general_exception),
+            (DasCliCommandException, self.handle_das_cli_command_error),
+            (DasCliNotInstalledException, self.handle_das_cli_not_installed_error),
+            (FileSaveException, self.handle_file_save_exception),
+            (FileAlreadyExistsException, self.handle_file_already_exists_error),
+            (RemoteSshConnectionError, self.handle_remote_ssh_connection_error),
+            (RemoteSshTransferError, self.handle_remote_ssh_transfer_error),
+            (DASServiceInstantiationError, self.handle_das_cli_service_error),
+            (CustomValueError, self.handle_custom_value_error),
+            (CommandRouterConnectionError, self.handle_command_router_connection_error),
+            (ConfigurationFileLoadError, self.handle_config_load_error),
+            (ConfigurationValueNotFoundError, self.handle_config_value_not_found)
+        ]
 
-        app.add_exception_handler(
-            DasCliNotInstalledException,
-            self.handle_das_cli_not_installed_error
-        )
-
-        app.add_exception_handler(
-            FileSaveException,
-            self.handle_file_save_exception
-        )
-
-        app.add_exception_handler(
-            FileAlreadyExistsException,
-            self.handle_file_already_exists_error
-        )
-
-        app.add_exception_handler(
-            RemoteSshConnectionError,
-            self.handle_remote_ssh_connection_error,
-        )
-
-        app.add_exception_handler(
-            RemoteSshTransferError,
-            self.handle_remote_ssh_transfer_error,
-        )
-
-        app.add_exception_handler(
-            Exception,
-            self.handle_general_exception
-        )
-
-        app.add_exception_handler(
-            DASServiceInstantiationError,
-            self.handle_das_cli_service_error,
-        )
-
-        app.add_exception_handler(
-            CustomValueError,
-            self.handle_custom_value_error,
-        )
-
-        app.add_exception_handler(
-            CommandRouterConnectionError,
-            self.handle_command_router_connection_error,
-        )
+        for exception, handler in CUSTOM_EXCEPTIONS:
+            app.add_exception_handler(
+                exception, handler
+            )
 
     async def handle_das_cli_command_error(
         self,
@@ -206,6 +178,31 @@ class AppExceptionHandlers:
         
         return JSONResponse(
             status_code=400,
+            content={
+                "message": exc.message
+            }
+        )
+
+    async def handle_config_value_not_found(
+            self,
+            request: Request,
+            exc: ConfigurationValueNotFoundError
+    ):
+
+        return JSONResponse(
+            status_code=500,
+            content={
+                "message": exc.message
+            }
+        )
+
+    async def handle_config_load_error(
+            self,
+            request: Request,
+            exc: ConfigurationFileLoadError
+    ):
+        return JSONResponse(
+            status_code=500,
             content={
                 "message": exc.message
             }

--- a/das-dashboard/backend/shared/internal/constants.py
+++ b/das-dashboard/backend/shared/internal/constants.py
@@ -7,6 +7,7 @@ SHARED_DAS_ROOT = os.environ.get("DAS_SHARED_ROOT", "/opt/web-das")
 CONFIG_DIR = os.path.join(SHARED_DAS_ROOT, ".das")
 
 CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
+QUERY_DB_PATH = os.path.join(CONFIG_DIR, "query_responses.db")
 DEFAULT_WEBPROFILE_PATH = os.path.join(CONFIG_DIR, "web_profile.json")
 DEFAULT_SSHKEY_CLONE_PATH = os.path.join(CONFIG_DIR, "web_key")
 ADAPTER_CONTEXT_MAPPING_FILE = os.path.join(CONFIG_DIR, "adapter_context_mapping.sql")

--- a/das-dashboard/backend/shared/internal/constants.py
+++ b/das-dashboard/backend/shared/internal/constants.py
@@ -21,4 +21,4 @@ REMOTE_METTA_FILES_PATH = f"{REMOTE_WORKSPACE_ROOT}/metta_files"
 REMOTE_CONFIG_PATH = "/.das/config.json"
 
 LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0"})
-LOCAL_DASHBOARD_HOST = "127.0.0.1"
+LOCAL_DASHBOARD_HOST = "localhost"

--- a/das-dashboard/backend/shared/internal/web_configuration.py
+++ b/das-dashboard/backend/shared/internal/web_configuration.py
@@ -1,6 +1,10 @@
 import json
 import os
 
+from shared.exceptions.custom_exceptions import (
+    ConfigurationFileLoadError,
+    ConfigurationValueNotFoundError,
+)
 from shared.internal.constants import (
     CONFIG_PATH,
     DEFAULT_WEBPROFILE_PATH as PROFILE_PATH,
@@ -41,30 +45,132 @@ class WebConfiguration:
         try:
             with open(PROFILE_PATH, "r") as f:
                 self.user_profile = json.load(f)
-        except:
+        except Exception:
             self.user_profile = {}
 
-    def load_config_dictionary(self):
+    def load_config_dictionary(self, config: dict | None = None, *, required: bool = True) -> None:
+        if config is not None:
+            self._validate_nested_config(config)
+            self.config_dictionary = self._build_service_map(config)
+            return
+
         if not os.path.exists(CONFIG_PATH):
+            if required:
+                raise ConfigurationFileLoadError(f"Configuration file not found: {CONFIG_PATH}")
             self.config_dictionary = {}
             return
 
         try:
-            with open(CONFIG_PATH, "r") as f:
-                config = json.load(f)
+            with open(CONFIG_PATH, "r") as config_file:
+                loaded = json.load(config_file)
+        except json.JSONDecodeError as error:
+            raise ConfigurationFileLoadError(
+                f"Invalid JSON in configuration file: {error}"
+            ) from error
+        except OSError as error:
+            raise ConfigurationFileLoadError(
+                f"Could not read configuration file: {error}"
+            ) from error
 
-            if isinstance(config, list):
-                config = config[0]
+        if isinstance(loaded, list):
+            if not loaded:
+                raise ConfigurationFileLoadError("Configuration file is empty.")
+            loaded = loaded[0]
 
-            self.config_dictionary = self.map_services(config)
-        except:
-            self.config_dictionary = {}
+        self._validate_nested_config(loaded)
+        self.config_dictionary = self._build_service_map(loaded)
 
-    def map_services(self, config_file: dict) -> dict:
+    def load_raw_configuration(self) -> dict:
+        if not os.path.exists(CONFIG_PATH):
+            raise ConfigurationFileLoadError(f"Configuration file not found: {CONFIG_PATH}")
+
+        try:
+            with open(CONFIG_PATH, "r") as file:
+                loaded = json.load(file)
+        except json.JSONDecodeError as error:
+            raise ConfigurationFileLoadError(
+                f"Invalid JSON in configuration file: {error}"
+            ) from error
+        except OSError as error:
+            raise ConfigurationFileLoadError(
+                f"Could not read configuration file: {error}"
+            ) from error
+
+        if isinstance(loaded, list):
+            if not loaded:
+                raise ConfigurationFileLoadError("Configuration file is empty.")
+            loaded = loaded[0]
+
+        self._validate_nested_config(loaded)
+        return loaded
+
+    def get_service_config(self, service_key: str, *, required: bool = True) -> dict | None:
+        service = self.config_dictionary.get(service_key)
+        if not service or not service.get("host"):
+            if required:
+                raise ConfigurationValueNotFoundError(service_key)
+            return None
+        return service
+
+    def require_config_dictionary(self) -> dict[str, dict]:
+        if not self.config_dictionary:
+            raise ConfigurationFileLoadError("Configuration has not been loaded.")
+        return self.config_dictionary
+
+    def map_remote_hosts(self) -> list[dict]:
+        _, remote_by_host = self._group_services_by_host(self.require_config_dictionary())
+
+        return [
+            {"ip": host, "labels": [service_key for service_key, _ in entries]}
+            for host, entries in sorted(remote_by_host.items(), key=lambda item: item[0])
+        ]
+
+    def map_dashboard_hosts(self) -> list[dict]:
+        local_entries, remote_by_host = self._group_services_by_host(
+            self.require_config_dictionary()
+        )
+
+        dashboard_hosts = [
+            {
+                "ip": host,
+                "services": [
+                    build_service_row(service_key, service)
+                    for service_key, service in entries
+                ],
+            }
+            for host, entries in sorted(remote_by_host.items(), key=lambda item: item[0])
+        ]
+
+        if local_entries:
+            dashboard_hosts.insert(
+                0,
+                {
+                    "ip": LOCAL_DASHBOARD_HOST,
+                    "services": [
+                        build_service_row(service_key, service)
+                        for service_key, service in local_entries
+                    ],
+                },
+            )
+
+        return dashboard_hosts
+
+    @staticmethod
+    def _validate_nested_config(config) -> None:
+        if not isinstance(config, dict):
+            raise ConfigurationFileLoadError("Configuration must be a JSON object.")
+
+        if "atomdb" not in config or "agents" not in config:
+            raise ConfigurationFileLoadError(
+                "Configuration must include 'atomdb' and 'agents' sections."
+            )
+
+    @classmethod
+    def _build_service_map(cls, config_file: dict) -> dict[str, dict]:
         services: dict[str, dict] = {}
 
         atomdb = config_file.get("atomdb") or {}
-        self._map_atomdb_section(services, atomdb)
+        cls._map_atomdb_section(services, atomdb)
 
         agents = config_file.get("agents") or {}
         for agent_key, command_name in AGENT_SERVICE_COMMANDS.items():
@@ -72,59 +178,30 @@ class WebConfiguration:
             if not isinstance(section, dict):
                 continue
 
-            self._register_endpoint(services, command_name, section.get("endpoint"))
+            cls._register_endpoint(services, command_name, section.get("endpoint"))
 
         return services
 
-    def map_hosts_from_config(self, config_file: dict) -> list[dict]:
-        return self._remote_hosts_from_services(self.map_services(config_file))
-
     @staticmethod
-    def _remote_hosts_from_services(services: dict) -> list[dict]:
-        hosts_by_ip: dict[str, dict] = {}
+    def _group_services_by_host(
+        services: dict[str, dict],
+    ) -> tuple[list[tuple[str, dict]], dict[str, list[tuple[str, dict]]]]:
+        local_entries: list[tuple[str, dict]] = []
+        remote_by_host: dict[str, list[tuple[str, dict]]] = {}
 
-        for service_name, service in services.items():
-            host = service.get("host", "")
-            if not host or host in LOCAL_HOSTS:
-                continue
-
-            if host not in hosts_by_ip:
-                hosts_by_ip[host] = {"ip": host, "labels": []}
-
-            hosts_by_ip[host]["labels"].append(service_name)
-
-        return sorted(hosts_by_ip.values(), key=lambda item: item["ip"])
-
-    def map_dashboard_hosts(self) -> list[dict]:
-        if not self.config_dictionary:
-            return []
-
-        hosts_by_ip: dict[str, dict] = {}
-        local_services: list[dict] = []
-
-        for service_key, service in self.config_dictionary.items():
+        for service_key, service in services.items():
             host = service.get("host", "")
             if not host:
                 continue
 
-            row = build_service_row(service_key, service)
-
+            entry = (service_key, service)
             if host in LOCAL_HOSTS:
-                local_services.append(row)
+                local_entries.append(entry)
                 continue
 
-            if host not in hosts_by_ip:
-                hosts_by_ip[host] = {"ip": host, "services": []}
+            remote_by_host.setdefault(host, []).append(entry)
 
-            hosts_by_ip[host]["services"].append(row)
-
-        dashboard_hosts = sorted(hosts_by_ip.values(), key=lambda item: item["ip"])
-
-        if local_services:
-            dashboard_hosts.insert(0, {"ip": LOCAL_DASHBOARD_HOST, "services": local_services})
-
-        return dashboard_hosts
-
+        return local_entries, remote_by_host
 
     @staticmethod
     def _register_endpoint(services: dict, name: str, endpoint: str | None) -> None:

--- a/das-dashboard/backend/shared/internal/web_configuration.py
+++ b/das-dashboard/backend/shared/internal/web_configuration.py
@@ -43,9 +43,9 @@ class WebConfiguration:
             return
 
         try:
-            with open(PROFILE_PATH, "r") as f:
-                self.user_profile = json.load(f)
-        except Exception:
+            with open(PROFILE_PATH) as profile_file:
+                self.user_profile = json.load(profile_file)
+        except (OSError, json.JSONDecodeError):
             self.user_profile = {}
 
     def load_config_dictionary(self, config: dict | None = None, *, required: bool = True) -> None:

--- a/das-dashboard/backend/shared/utils/das_cli_config.py
+++ b/das-dashboard/backend/shared/utils/das_cli_config.py
@@ -2,26 +2,39 @@ import json
 import os
 import subprocess
 
-from shared.exceptions.custom_exceptions import DasCliCommandException, DasCliNotInstalledException
+from shared.exceptions.custom_exceptions import DasCliCommandException, DasCliNotInstalledException, ConfigurationFileLoadError
 from shared.internal.constants import DEFAULT_SSHKEY_CLONE_PATH, LOCAL_HOSTS
 from shared.internal.web_configuration import WebConfiguration
 
 
 def _validate_config_file(file_path: str) -> None:
     if not os.path.isfile(file_path):
-        raise ValueError(f"Configuration file not found: {file_path}")
+        raise ConfigurationFileLoadError(f"Configuration file not found: {file_path}")
 
-    with open(file_path, "r", encoding="utf-8") as config_file:
-        data = json.load(config_file)
+    try:
+        with open(file_path, "r", encoding="utf-8") as config_file:
+            data = json.load(config_file)
+    except json.JSONDecodeError as error:
+        raise ConfigurationFileLoadError(
+            f"Invalid JSON in configuration file: {error}"
+        ) from error
+    except OSError as error:
+        raise ConfigurationFileLoadError(
+            f"Could not read configuration file: {error}"
+        ) from error
 
     if isinstance(data, list):
+        if not data:
+            raise ConfigurationFileLoadError("Configuration file is empty.")
         data = data[0]
 
     if not isinstance(data, dict):
-        raise ValueError("Configuration file must be a JSON object.")
+        raise ConfigurationFileLoadError("Configuration file must be a JSON object.")
 
     if "atomdb" not in data or "agents" not in data:
-        raise ValueError("Configuration file must include 'atomdb' and 'agents' sections.")
+        raise ConfigurationFileLoadError(
+            "Configuration file must include 'atomdb' and 'agents' sections."
+        )
 
 
 def set_das_cli_config(

--- a/das-dashboard/backend/shared/utils/parse_query_answer.py
+++ b/das-dashboard/backend/shared/utils/parse_query_answer.py
@@ -1,0 +1,28 @@
+import re
+
+SCORES_PATTERN = re.compile(r" \(([-\d.]+),\s*([-\d.]+)\)\s*$")
+ASSIGNMENT_PATTERN = re.compile(r"\{([^}]+)\}")
+
+
+def parse_query_answer(text: str) -> dict:
+    scores_match = SCORES_PATTERN.search(text)
+    strength = 0.0
+    importance = 0.0
+    body = text
+
+    if scores_match:
+        strength = float(scores_match.group(1))
+        importance = float(scores_match.group(2))
+        body = text[: scores_match.start()]
+
+    assignment_label = None
+    assignment_match = ASSIGNMENT_PATTERN.search(body)
+    if assignment_match:
+        assignment_label = assignment_match.group(1).strip()
+
+    return {
+        "answer_text": text,
+        "strength": strength,
+        "importance": importance,
+        "assignment_label": assignment_label,
+    }

--- a/das-dashboard/backend/shared/utils/parse_query_answer.py
+++ b/das-dashboard/backend/shared/utils/parse_query_answer.py
@@ -8,10 +8,25 @@ def normalize_query_answer(item: Any) -> dict[str, Any] | None:
     if not isinstance(item, dict):
         return None
 
-    if not any(key in item for key in ("handles", "metta", "assignment")):
+    if "handles" not in item or "assignment" not in item:
         return None
 
-    return item
+    metta_expressions = item.get("metta_expressions")
+    if metta_expressions is None:
+        metta_expressions = item.get("metta", [])
+
+    normalized = dict(item)
+    normalized.update(
+        {
+            "handles": item.get("handles", []),
+            "assignment": item.get("assignment", {}),
+            "metta_expressions": metta_expressions or [],
+            "assignment_metta": item.get("assignment_metta", {}),
+            "importance": float(item.get("importance", 0.0)),
+            "strength": float(item.get("strength", 0.0)),
+        }
+    )
+    return normalized
 
 
 def transform_stream_event(event: dict[str, Any]) -> dict[str, Any]:

--- a/das-dashboard/backend/shared/utils/parse_query_answer.py
+++ b/das-dashboard/backend/shared/utils/parse_query_answer.py
@@ -1,58 +1,17 @@
-import re
 from typing import Any
 
-# QueryAnswer<1,1> [[...]] {(V: "onivore")} (0.000000, 0.000000)
-HEADER = re.compile(r"^QueryAnswer<\d+,\d+>\s+")
-SCORES = re.compile(r" \(([-\d.]+),\s*([-\d.]+)\)\s*$")
-ASSIGNMENT = re.compile(r"\{([^}]+)\}")
-HANDLES = re.compile(r"\[\[(.*?)\]\]", re.DOTALL)
-BINDING = re.compile(r"\(\s*([^:]+):\s*(.+)\s*\)")
-COUNT_ONLY = re.compile(r"^\d+$")
 
+def normalize_query_answer(item: Any) -> dict[str, Any] | None:
+    if isinstance(item, str) and item.strip().isdigit():
+        return {"count_only": True, "count": int(item.strip())}
 
-def parse_query_answer(text: str) -> dict[str, Any]:
-    if not isinstance(text, str) or not text.strip():
-        return {"response": "", "importance": 0.0, "count_only": False}
+    if not isinstance(item, dict):
+        return None
 
-    stripped = text.strip()
+    if not any(key in item for key in ("handles", "metta", "assignment")):
+        return None
 
-    if COUNT_ONLY.match(stripped):
-        return {
-            "response": stripped,
-            "importance": 0.0,
-            "count_only": True,
-        }
-
-    importance = 0.0
-    body = text
-
-    scores = SCORES.search(text)
-    if scores:
-        importance = float(scores.group(2))
-        body = text[: scores.start()]
-
-    response = stripped
-
-    assignment = ASSIGNMENT.search(body)
-    if assignment:
-        binding = BINDING.search(assignment.group(1))
-        if binding and binding.group(2).strip():
-            response = binding.group(2).strip().strip('"')
-            return {
-                "response": response,
-                "importance": importance,
-                "count_only": False,
-            }
-
-    handles = HANDLES.search(body)
-    if handles and handles.group(1).strip():
-        response = handles.group(1).strip()
-
-    return {
-        "response": response,
-        "importance": importance,
-        "count_only": False,
-    }
+    return item
 
 
 def transform_stream_event(event: dict[str, Any]) -> dict[str, Any]:
@@ -65,18 +24,9 @@ def transform_stream_event(event: dict[str, Any]) -> dict[str, Any]:
 
     data = []
     for item in raw_items:
-        if isinstance(item, str):
-            data.append(parse_query_answer(item))
-            continue
-
-        if isinstance(item, dict) and "response" in item:
-            data.append(
-                {
-                    "response": item.get("response", ""),
-                    "importance": float(item.get("importance", 0.0)),
-                    "count_only": bool(item.get("count_only", False)),
-                }
-            )
+        normalized = normalize_query_answer(item)
+        if normalized is not None:
+            data.append(normalized)
 
     return {
         "execution_id": event.get("execution_id"),

--- a/das-dashboard/backend/shared/utils/parse_query_answer.py
+++ b/das-dashboard/backend/shared/utils/parse_query_answer.py
@@ -1,28 +1,87 @@
 import re
+from typing import Any
 
-SCORES_PATTERN = re.compile(r" \(([-\d.]+),\s*([-\d.]+)\)\s*$")
-ASSIGNMENT_PATTERN = re.compile(r"\{([^}]+)\}")
+# QueryAnswer<1,1> [[...]] {(V: "onivore")} (0.000000, 0.000000)
+HEADER = re.compile(r"^QueryAnswer<\d+,\d+>\s+")
+SCORES = re.compile(r" \(([-\d.]+),\s*([-\d.]+)\)\s*$")
+ASSIGNMENT = re.compile(r"\{([^}]+)\}")
+HANDLES = re.compile(r"\[\[(.*?)\]\]", re.DOTALL)
+BINDING = re.compile(r"\(\s*([^:]+):\s*(.+)\s*\)")
+COUNT_ONLY = re.compile(r"^\d+$")
 
 
-def parse_query_answer(text: str) -> dict:
-    scores_match = SCORES_PATTERN.search(text)
-    strength = 0.0
+def parse_query_answer(text: str) -> dict[str, Any]:
+    if not isinstance(text, str) or not text.strip():
+        return {"response": "", "importance": 0.0, "count_only": False}
+
+    stripped = text.strip()
+
+    if COUNT_ONLY.match(stripped):
+        return {
+            "response": stripped,
+            "importance": 0.0,
+            "count_only": True,
+        }
+
     importance = 0.0
     body = text
 
-    if scores_match:
-        strength = float(scores_match.group(1))
-        importance = float(scores_match.group(2))
-        body = text[: scores_match.start()]
+    scores = SCORES.search(text)
+    if scores:
+        importance = float(scores.group(2))
+        body = text[: scores.start()]
 
-    assignment_label = None
-    assignment_match = ASSIGNMENT_PATTERN.search(body)
-    if assignment_match:
-        assignment_label = assignment_match.group(1).strip()
+    response = stripped
+
+    assignment = ASSIGNMENT.search(body)
+    if assignment:
+        binding = BINDING.search(assignment.group(1))
+        if binding and binding.group(2).strip():
+            response = binding.group(2).strip().strip('"')
+            return {
+                "response": response,
+                "importance": importance,
+                "count_only": False,
+            }
+
+    handles = HANDLES.search(body)
+    if handles and handles.group(1).strip():
+        response = handles.group(1).strip()
 
     return {
-        "answer_text": text,
-        "strength": strength,
+        "response": response,
         "importance": importance,
-        "assignment_label": assignment_label,
+        "count_only": False,
+    }
+
+
+def transform_stream_event(event: dict[str, Any]) -> dict[str, Any]:
+    if event.get("type") != "chunk":
+        return event
+
+    raw_items = event.get("data")
+    if not isinstance(raw_items, list):
+        return event
+
+    data = []
+    for item in raw_items:
+        if isinstance(item, str):
+            data.append(parse_query_answer(item))
+            continue
+
+        if isinstance(item, dict) and "response" in item:
+            data.append(
+                {
+                    "response": item.get("response", ""),
+                    "importance": float(item.get("importance", 0.0)),
+                    "count_only": bool(item.get("count_only", False)),
+                }
+            )
+
+    return {
+        "execution_id": event.get("execution_id"),
+        "type": "chunk",
+        "seq": event.get("seq"),
+        "received_count": event.get("received_count"),
+        "data": data,
     }

--- a/das-dashboard/backend/shared/utils/parse_query_answer.py
+++ b/das-dashboard/backend/shared/utils/parse_query_answer.py
@@ -1,6 +1,13 @@
 from typing import Any
 
 
+def _to_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def normalize_query_answer(item: Any) -> dict[str, Any] | None:
     if isinstance(item, str) and item.strip().isdigit():
         return {"count_only": True, "count": int(item.strip())}
@@ -22,8 +29,8 @@ def normalize_query_answer(item: Any) -> dict[str, Any] | None:
             "assignment": item.get("assignment", {}),
             "metta_expressions": metta_expressions or [],
             "assignment_metta": item.get("assignment_metta", {}),
-            "importance": float(item.get("importance", 0.0)),
-            "strength": float(item.get("strength", 0.0)),
+            "importance": _to_float(item.get("importance")),
+            "strength": _to_float(item.get("strength")),
         }
     )
     return normalized

--- a/das-dashboard/src/App.jsx
+++ b/das-dashboard/src/App.jsx
@@ -5,11 +5,12 @@ import { BrowserRouter, Route, Routes } from 'react-router'
 import './App.css'
 
 import { Box } from "@mui/material"
-import Navbar from "./components/top_nav_bar/NavBar.jsx"
+import NavBar from "./components/top_nav_bar/NavBar.jsx"
 import SetupDasPage from './pages/setup_das/SetupDas.jsx'
 import DashboardPage from './pages/dashboard/Dashboard.jsx'
 import DashboardContextProvider from './components/global_providers/DashboardContextProvider.jsx'
 import ProfilePage from './pages/profile/ProfilePage.jsx'
+import QueryPage from './pages/query/QueryPage.jsx'
 import { DialogProvider } from './components/global_providers/DialogProvider.jsx'
 
 
@@ -18,17 +19,18 @@ function App() {
   return (
     <>
       <BrowserRouter>
-        <DashboardContextProvider>
         <Box sx={{ display: "flex", flexDirection: "column", height: "100vh", overflow: "hidden" }}>
-          <Navbar />
+          <NavBar />
           <Box component="main" sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
             <Routes>
                   <Route path='/configuration' element={
                     <DialogProvider>
                       <ToastProvider>
-                        <ConfigurationProvider>
-                          <SetupDasPage/>
-                        </ConfigurationProvider>
+                        <DashboardContextProvider>
+                          <ConfigurationProvider>
+                            <SetupDasPage/>
+                          </ConfigurationProvider>
+                        </DashboardContextProvider>
                       </ToastProvider>
                     </DialogProvider>
                   }/>
@@ -42,14 +44,20 @@ function App() {
                   <Route path='/dashboard' element={
                     <DialogProvider>
                       <ToastProvider>
-                          <DashboardPage />
+                        <DashboardPage />
+                      </ToastProvider>
+                    </DialogProvider>
+                  }/>
+                  <Route path='/query' element={
+                    <DialogProvider>
+                      <ToastProvider>
+                        <QueryPage />
                       </ToastProvider>
                     </DialogProvider>
                   }/>
             </Routes>
           </Box>
         </Box>
-        </DashboardContextProvider>
       </BrowserRouter>
     </>
   )

--- a/das-dashboard/src/api/AxiosBaseClient.js
+++ b/das-dashboard/src/api/AxiosBaseClient.js
@@ -1,7 +1,8 @@
 import axios from "axios";
+import { resolveHttpBaseUrl } from "./apiBase";
 
 const api = axios.create({
-  baseURL: "http://localhost:8000",
+  baseURL: resolveHttpBaseUrl(),
 });
 
 export default api

--- a/das-dashboard/src/api/QueryAPI.js
+++ b/das-dashboard/src/api/QueryAPI.js
@@ -1,0 +1,9 @@
+import api from "./AxiosBaseClient";
+
+export async function setQueryParameters(params) {
+  const response = await api.post("/query/executions", {
+    command_type: "set",
+    command_text: JSON.stringify(params)
+  });
+  return response.data;
+}

--- a/das-dashboard/src/api/QueryAPI.js
+++ b/das-dashboard/src/api/QueryAPI.js
@@ -1,5 +1,10 @@
 import api from "./AxiosBaseClient";
 
+export async function getQueryParamDefaults() {
+  const response = await api.get("/query/param/defaults");
+  return response.data;
+}
+
 export async function setQueryParameters(params) {
   const response = await api.post("/query/executions", {
     command_type: "set",

--- a/das-dashboard/src/api/QueryAPI.js
+++ b/das-dashboard/src/api/QueryAPI.js
@@ -7,3 +7,28 @@ export async function setQueryParameters(params) {
   });
   return response.data;
 }
+
+export async function startQueryExecution(queryText) {
+  const response = await api.post("/query/executions", {
+    command_type: "query",
+    command_text: queryText
+  });
+  return response.data;
+}
+
+export async function getQueryExecutionStatus(executionId) {
+  const response = await api.get(`/query/executions/${executionId}`);
+  return response.data;
+}
+
+export async function getQueryAnswers(executionId, page = 1, pageSize = 10) {
+  const response = await api.get(`/query/executions/${executionId}/answers`, {
+    params: { page, page_size: pageSize }
+  });
+  return response.data;
+}
+
+export async function cancelQueryExecution(executionId) {
+  const response = await api.post(`/query/executions/${executionId}/cancel`);
+  return response.data;
+}

--- a/das-dashboard/src/api/QueryStreamService.js
+++ b/das-dashboard/src/api/QueryStreamService.js
@@ -1,4 +1,6 @@
-const WS_BASE = "ws://localhost:8000";
+import { resolveWsBaseUrl } from "./apiBase";
+
+const WS_BASE = resolveWsBaseUrl();
 
 export function createQueryExecutionStream(executionId, { onEvent, onOpen, onClose, onError }) {
   const socket = new WebSocket(`${WS_BASE}/query/executions/${executionId}`);

--- a/das-dashboard/src/api/QueryStreamService.js
+++ b/das-dashboard/src/api/QueryStreamService.js
@@ -1,0 +1,41 @@
+const WS_BASE = "ws://localhost:8000";
+
+export function createQueryExecutionStream(executionId, { onEvent, onOpen, onClose, onError }) {
+  const socket = new WebSocket(`${WS_BASE}/query/executions/${executionId}`);
+
+  socket.onopen = () => {
+    onOpen?.();
+  };
+
+  socket.onmessage = (event) => {
+    try {
+      onEvent?.(JSON.parse(event.data));
+    } catch (error) {
+      onError?.({
+        type: "parse",
+        message: error.message
+      });
+    }
+  };
+
+  socket.onerror = () => {
+    onError?.({
+      type: "transport",
+      message: "Query stream connection error."
+    });
+  };
+
+  socket.onclose = (event) => {
+    onClose?.({
+      code: event.code,
+      reason: event.reason,
+      wasClean: event.wasClean
+    });
+  };
+
+  return {
+    close: () => {
+      socket.close();
+    }
+  };
+}

--- a/das-dashboard/src/api/apiBase.js
+++ b/das-dashboard/src/api/apiBase.js
@@ -1,0 +1,14 @@
+export function resolveHttpBaseUrl() {
+  const configured = import.meta.env.VITE_API_BASE_URL;
+  if (configured) {
+    return configured.replace(/\/$/, "");
+  }
+
+  return `${window.location.protocol}//${window.location.hostname}:8000`;
+}
+
+export function resolveWsBaseUrl() {
+  const url = new URL(resolveHttpBaseUrl());
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.origin;
+}

--- a/das-dashboard/src/components/global_providers/QueryExecutionProvider.jsx
+++ b/das-dashboard/src/components/global_providers/QueryExecutionProvider.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from "react";
+import { useQueryExecution } from "../../hooks/useQueryExecution";
+import { QueryParametersProvider, useQueryParameters } from "../../hooks/useQueryParameters";
+
+const QueryExecutionContext = createContext(null);
+
+function QueryExecutionProviderInner({ children }) {
+  const parameters = useQueryParameters();
+  const queryExecution = useQueryExecution(parameters);
+
+  return (
+    <QueryExecutionContext.Provider value={queryExecution}>
+      {children}
+    </QueryExecutionContext.Provider>
+  );
+}
+
+export function QueryExecutionProvider({ children }) {
+  return (
+    <QueryParametersProvider>
+      <QueryExecutionProviderInner>{children}</QueryExecutionProviderInner>
+    </QueryParametersProvider>
+  );
+}
+
+export function useQueryExecutionContext() {
+  const context = useContext(QueryExecutionContext);
+  if (!context) {
+    throw new Error("useQueryExecutionContext must be used inside QueryExecutionProvider");
+  }
+  return context;
+}

--- a/das-dashboard/src/components/query_page/ParameterSection.jsx
+++ b/das-dashboard/src/components/query_page/ParameterSection.jsx
@@ -150,6 +150,7 @@ export default function ParameterSection() {
             value={maxBundleSize}
             onChange={(event) => setMaxBundleSize(Number(event.target.value))}
             fullWidth
+            inputProps={{ min: 1, step: 1 }}
             sx={fieldSx}
           />
         </ParameterFieldGrid>

--- a/das-dashboard/src/components/query_page/ParameterSection.jsx
+++ b/das-dashboard/src/components/query_page/ParameterSection.jsx
@@ -1,0 +1,254 @@
+import { useState } from "react";
+import {
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Slider,
+  Switch,
+  TextField
+} from "@mui/material";
+import {
+  ParameterDivider,
+  ParameterFieldGrid,
+  ParameterLimitField,
+  ParameterSectionBody,
+  ParameterSwitchStack,
+  SliderLabel,
+  SliderLabelRow,
+  SliderRow,
+  SliderValue,
+  paletteQuery
+} from "../../pages/query/querypage.styled";
+
+const ATTENTION_OPTIONS = [
+  { value: 0, label: "None" },
+  { value: 1, label: "Handles" },
+  { value: 2, label: "Variables" },
+  { value: 3, label: "Handles and variables" }
+];
+
+const BASE_QUERY_SWITCHES = [
+  { key: "unique_assignment_flag", label: "Unique assignment" },
+  { key: "use_link_template_cache", label: "Use link template cache" },
+  { key: "populate_metta_mapping", label: "Populate MeTTa mapping" },
+  { key: "use_metta_as_query_tokens", label: "Use MeTTa as query tokens" },
+  { key: "allow_incomplete_chain_path", label: "Allow incomplete chain path" }
+];
+
+const QUERY_SWITCHES = [
+  { key: "positive_importance_flag", label: "Only answers with non-zero STI" },
+  { key: "disregard_importance_flag", label: "Disregard STI" },
+  { key: "unique_value_flag", label: "Unique value" },
+  { key: "count_flag", label: "Count only" }
+];
+
+const fieldSx = {
+  "& .MuiOutlinedInput-root": {
+    backgroundColor: paletteQuery.surface,
+    fontSize: 13
+  },
+  "& .MuiInputLabel-root": {
+    fontSize: 13
+  }
+};
+
+const switchSx = {
+  mx: 0,
+  width: "100%",
+  justifyContent: "space-between",
+  ml: 0,
+  mr: 0,
+  "& .MuiFormControlLabel-label": {
+    fontSize: 13,
+    color: paletteQuery.textPrimary
+  }
+};
+
+const INITIAL_SWITCH_STATE = Object.fromEntries(
+  [...BASE_QUERY_SWITCHES, ...QUERY_SWITCHES].map((item) => [item.key, false])
+);
+
+export default function ParameterSection() {
+  const [attentionUpdate, setAttentionUpdate] = useState(0);
+  const [attentionCorrelation, setAttentionCorrelation] = useState(1);
+  const [attentionFocusStrictness, setAttentionFocusStrictness] = useState(0);
+  const [maxBundleSize, setMaxBundleSize] = useState(1000);
+  const [limitAnswersEnabled, setLimitAnswersEnabled] = useState(false);
+  const [maxAnswersLimit, setMaxAnswersLimit] = useState(1);
+  const [switches, setSwitches] = useState(INITIAL_SWITCH_STATE);
+
+  const limitValueInvalid =
+    limitAnswersEnabled &&
+    (!Number.isInteger(maxAnswersLimit) || maxAnswersLimit < 1);
+
+  const updateSwitch = (key, checked) => {
+    setSwitches((previous) => ({ ...previous, [key]: checked }));
+  };
+
+  return (
+    <ParameterSectionBody>
+      <ParameterFieldGrid>
+        <FormControl size="small" fullWidth sx={fieldSx}>
+          <InputLabel>Attention update</InputLabel>
+          <Select
+            label="Attention update"
+            value={attentionUpdate}
+            onChange={(event) => setAttentionUpdate(event.target.value)}
+          >
+            {ATTENTION_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" fullWidth sx={fieldSx}>
+          <InputLabel>Attention correlation</InputLabel>
+          <Select
+            label="Attention correlation"
+            value={attentionCorrelation}
+            onChange={(event) => setAttentionCorrelation(event.target.value)}
+          >
+            {ATTENTION_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </ParameterFieldGrid>
+
+      <SliderRow>
+        <SliderLabelRow>
+          <SliderLabel>Attention focus strictness</SliderLabel>
+          <SliderValue>{attentionFocusStrictness.toFixed(1)}</SliderValue>
+        </SliderLabelRow>
+        <Slider
+          size="small"
+          value={attentionFocusStrictness}
+          onChange={(_, value) => setAttentionFocusStrictness(value)}
+          min={0}
+          max={1}
+          step={0.1}
+          sx={{
+            color: paletteQuery.accent,
+            "& .MuiSlider-rail": { opacity: 0.35 }
+          }}
+        />
+      </SliderRow>
+
+      <ParameterFieldGrid>
+        <TextField
+          label="Max bundle size"
+          type="number"
+          size="small"
+          value={maxBundleSize}
+          onChange={(event) => setMaxBundleSize(Number(event.target.value))}
+          fullWidth
+          sx={fieldSx}
+        />
+      </ParameterFieldGrid>
+
+      <ParameterLimitField>
+        <FormControlLabel
+          sx={switchSx}
+          labelPlacement="start"
+          control={
+            <Switch
+              size="small"
+              checked={limitAnswersEnabled}
+              onChange={(event) => setLimitAnswersEnabled(event.target.checked)}
+              sx={{
+                "& .MuiSwitch-switchBase.Mui-checked": {
+                  color: paletteQuery.accent
+                },
+                "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                  backgroundColor: paletteQuery.accent
+                }
+              }}
+            />
+          }
+          label="Limit the number of answers"
+        />
+
+        <TextField
+          label="Answer limit"
+          type="number"
+          size="small"
+          value={maxAnswersLimit}
+          disabled={!limitAnswersEnabled}
+          error={limitValueInvalid}
+          helperText={
+            limitValueInvalid ? "Enter an integer greater than or equal to 1." : " "
+          }
+          onChange={(event) => {
+            const parsed = Number.parseInt(event.target.value, 10);
+            if (!Number.isNaN(parsed)) {
+              setMaxAnswersLimit(parsed);
+            }
+          }}
+          inputProps={{ min: 1, step: 1 }}
+          fullWidth
+          sx={fieldSx}
+        />
+      </ParameterLimitField>
+
+      <ParameterSwitchStack>
+        {BASE_QUERY_SWITCHES.map((item) => (
+          <FormControlLabel
+            key={item.key}
+            sx={switchSx}
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={switches[item.key]}
+                onChange={(event) => updateSwitch(item.key, event.target.checked)}
+                sx={{
+                  "& .MuiSwitch-switchBase.Mui-checked": {
+                    color: paletteQuery.accent
+                  },
+                  "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                    backgroundColor: paletteQuery.accent
+                  }
+                }}
+              />
+            }
+            label={item.label}
+          />
+        ))}
+      </ParameterSwitchStack>
+
+      <ParameterDivider />
+
+      <ParameterSwitchStack>
+        {QUERY_SWITCHES.map((item) => (
+          <FormControlLabel
+            key={item.key}
+            sx={switchSx}
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={switches[item.key]}
+                onChange={(event) => updateSwitch(item.key, event.target.checked)}
+                sx={{
+                  "& .MuiSwitch-switchBase.Mui-checked": {
+                    color: paletteQuery.accent
+                  },
+                  "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                    backgroundColor: paletteQuery.accent
+                  }
+                }}
+              />
+            }
+            label={item.label}
+          />
+        ))}
+      </ParameterSwitchStack>
+    </ParameterSectionBody>
+  );
+}

--- a/das-dashboard/src/components/query_page/ParameterSection.jsx
+++ b/das-dashboard/src/components/query_page/ParameterSection.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
   FormControl,
   FormControlLabel,
@@ -9,13 +8,8 @@ import {
   Switch,
   TextField
 } from "@mui/material";
-import { setQueryParameters } from "../../api/QueryAPI";
-import { extractErrorDetails } from "../../api/APIUtils";
-import { useToast } from "../global_providers/ToastProvider";
 import { useQueryParameters } from "../../hooks/useQueryParameters";
 import {
-  ApplyParametersButton,
-  ParameterApplyFooter,
   ParameterDivider,
   ParameterFieldGrid,
   ParameterLimitField,
@@ -40,7 +34,6 @@ const BASE_QUERY_SWITCHES = [
   { key: "unique_assignment_flag", label: "Unique assignment" },
   { key: "use_link_template_cache", label: "Use link template cache" },
   { key: "populate_metta_mapping", label: "Populate MeTTa mapping" },
-  { key: "use_metta_as_query_tokens", label: "Use MeTTa as query tokens" },
   { key: "allow_incomplete_chain_path", label: "Allow incomplete chain path" }
 ];
 
@@ -88,52 +81,12 @@ export default function ParameterSection() {
     maxAnswersLimit,
     setMaxAnswersLimit,
     switches,
-    updateSwitch,
-    collectParameters,
-    markParametersApplied
+    updateSwitch
   } = useQueryParameters();
-
-  const { showToast } = useToast();
-  const [isApplying, setIsApplying] = useState(false);
-
-  useEffect(() => {
-    if (!isApplying) {
-      return undefined;
-    }
-
-    document.body.style.cursor = "wait";
-
-    return () => {
-      document.body.style.cursor = "";
-    };
-  }, [isApplying]);
 
   const limitValueInvalid =
     limitAnswersEnabled &&
     (!Number.isInteger(maxAnswersLimit) || maxAnswersLimit < 1);
-
-  const handleApplyParameters = async () => {
-    if (limitValueInvalid || isApplying) {
-      return;
-    }
-
-    setIsApplying(true);
-
-    try {
-      const params = collectParameters();
-      await setQueryParameters(params);
-      markParametersApplied(params);
-      showToast({ message: "Query parameters applied.", severity: "success" });
-    } catch (error) {
-      showToast({
-        message: "Failed to apply query parameters.",
-        severity: "error",
-        details: extractErrorDetails(error)
-      });
-    } finally {
-      setIsApplying(false);
-    }
-  };
 
   return (
     <ParameterSectionRoot>
@@ -299,18 +252,6 @@ export default function ParameterSection() {
           ))}
         </ParameterSwitchStack>
       </ParameterSectionBody>
-
-      <ParameterApplyFooter>
-        <ApplyParametersButton
-          variant="contained"
-          disableElevation
-          fullWidth
-          disabled={limitValueInvalid || isApplying}
-          onClick={handleApplyParameters}
-        >
-          {isApplying ? "Applying…" : "Apply parameters"}
-        </ApplyParametersButton>
-      </ParameterApplyFooter>
     </ParameterSectionRoot>
   );
 }

--- a/das-dashboard/src/components/query_page/ParameterSection.jsx
+++ b/das-dashboard/src/components/query_page/ParameterSection.jsx
@@ -9,11 +9,18 @@ import {
   Switch,
   TextField
 } from "@mui/material";
+import { setQueryParameters } from "../../api/QueryAPI";
+import { extractErrorDetails } from "../../api/APIUtils";
+import { buildQueryParameters } from "../../utils/queryParameters";
 import {
+  ApplyParametersButton,
+  ParameterApplyFooter,
+  ParameterApplyMessage,
   ParameterDivider,
   ParameterFieldGrid,
   ParameterLimitField,
   ParameterSectionBody,
+  ParameterSectionRoot,
   ParameterSwitchStack,
   SliderLabel,
   SliderLabelRow,
@@ -72,12 +79,15 @@ const INITIAL_SWITCH_STATE = Object.fromEntries(
 
 export default function ParameterSection() {
   const [attentionUpdate, setAttentionUpdate] = useState(0);
-  const [attentionCorrelation, setAttentionCorrelation] = useState(1);
+  const [attentionCorrelation, setAttentionCorrelation] = useState(0);
   const [attentionFocusStrictness, setAttentionFocusStrictness] = useState(0);
   const [maxBundleSize, setMaxBundleSize] = useState(1000);
   const [limitAnswersEnabled, setLimitAnswersEnabled] = useState(false);
   const [maxAnswersLimit, setMaxAnswersLimit] = useState(1);
   const [switches, setSwitches] = useState(INITIAL_SWITCH_STATE);
+  const [isApplying, setIsApplying] = useState(false);
+  const [applyMessage, setApplyMessage] = useState(null);
+  const [applyMessageType, setApplyMessageType] = useState(null);
 
   const limitValueInvalid =
     limitAnswersEnabled &&
@@ -87,168 +97,219 @@ export default function ParameterSection() {
     setSwitches((previous) => ({ ...previous, [key]: checked }));
   };
 
+  const collectParameters = () =>
+    buildQueryParameters({
+      attentionUpdate,
+      attentionCorrelation,
+      attentionFocusStrictness,
+      maxBundleSize,
+      limitAnswersEnabled,
+      maxAnswersLimit,
+      switches
+    });
+
+  const handleApplyParameters = async () => {
+    if (limitValueInvalid || isApplying) {
+      return;
+    }
+
+    setIsApplying(true);
+    setApplyMessage(null);
+    setApplyMessageType(null);
+
+    try {
+      await setQueryParameters(collectParameters());
+      setApplyMessage("Parameters applied.");
+      setApplyMessageType("success");
+    } catch (error) {
+      setApplyMessage(extractErrorDetails(error));
+      setApplyMessageType("error");
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
   return (
-    <ParameterSectionBody>
-      <ParameterFieldGrid>
-        <FormControl size="small" fullWidth sx={fieldSx}>
-          <InputLabel>Attention update</InputLabel>
-          <Select
-            label="Attention update"
-            value={attentionUpdate}
-            onChange={(event) => setAttentionUpdate(event.target.value)}
-          >
-            {ATTENTION_OPTIONS.map((option) => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+    <ParameterSectionRoot>
+      <ParameterSectionBody>
+        <ParameterFieldGrid>
+          <FormControl size="small" fullWidth sx={fieldSx}>
+            <InputLabel>Attention update</InputLabel>
+            <Select
+              label="Attention update"
+              value={attentionUpdate}
+              onChange={(event) => setAttentionUpdate(event.target.value)}
+            >
+              {ATTENTION_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
 
-        <FormControl size="small" fullWidth sx={fieldSx}>
-          <InputLabel>Attention correlation</InputLabel>
-          <Select
-            label="Attention correlation"
-            value={attentionCorrelation}
-            onChange={(event) => setAttentionCorrelation(event.target.value)}
-          >
-            {ATTENTION_OPTIONS.map((option) => (
-              <MenuItem key={option.value} value={option.value}>
-                {option.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </ParameterFieldGrid>
+          <FormControl size="small" fullWidth sx={fieldSx}>
+            <InputLabel>Attention correlation</InputLabel>
+            <Select
+              label="Attention correlation"
+              value={attentionCorrelation}
+              onChange={(event) => setAttentionCorrelation(event.target.value)}
+            >
+              {ATTENTION_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </ParameterFieldGrid>
 
-      <SliderRow>
-        <SliderLabelRow>
-          <SliderLabel>Attention focus strictness</SliderLabel>
-          <SliderValue>{attentionFocusStrictness.toFixed(1)}</SliderValue>
-        </SliderLabelRow>
-        <Slider
-          size="small"
-          value={attentionFocusStrictness}
-          onChange={(_, value) => setAttentionFocusStrictness(value)}
-          min={0}
-          max={1}
-          step={0.1}
-          sx={{
-            color: paletteQuery.accent,
-            "& .MuiSlider-rail": { opacity: 0.35 }
-          }}
-        />
-      </SliderRow>
+        <SliderRow>
+          <SliderLabelRow>
+            <SliderLabel>Attention focus strictness</SliderLabel>
+            <SliderValue>{attentionFocusStrictness.toFixed(1)}</SliderValue>
+          </SliderLabelRow>
+          <Slider
+            size="small"
+            value={attentionFocusStrictness}
+            onChange={(_, value) => setAttentionFocusStrictness(value)}
+            min={0}
+            max={1}
+            step={0.1}
+            sx={{
+              color: paletteQuery.accent,
+              "& .MuiSlider-rail": { opacity: 0.35 }
+            }}
+          />
+        </SliderRow>
 
-      <ParameterFieldGrid>
-        <TextField
-          label="Max bundle size"
-          type="number"
-          size="small"
-          value={maxBundleSize}
-          onChange={(event) => setMaxBundleSize(Number(event.target.value))}
-          fullWidth
-          sx={fieldSx}
-        />
-      </ParameterFieldGrid>
+        <ParameterFieldGrid>
+          <TextField
+            label="Max bundle size"
+            type="number"
+            size="small"
+            value={maxBundleSize}
+            onChange={(event) => setMaxBundleSize(Number(event.target.value))}
+            fullWidth
+            sx={fieldSx}
+          />
+        </ParameterFieldGrid>
 
-      <ParameterLimitField>
-        <FormControlLabel
-          sx={switchSx}
-          labelPlacement="start"
-          control={
-            <Switch
-              size="small"
-              checked={limitAnswersEnabled}
-              onChange={(event) => setLimitAnswersEnabled(event.target.checked)}
-              sx={{
-                "& .MuiSwitch-switchBase.Mui-checked": {
-                  color: paletteQuery.accent
-                },
-                "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
-                  backgroundColor: paletteQuery.accent
-                }
-              }}
+        <ParameterLimitField>
+          <FormControlLabel
+            sx={switchSx}
+            labelPlacement="start"
+            control={
+              <Switch
+                size="small"
+                checked={limitAnswersEnabled}
+                onChange={(event) => setLimitAnswersEnabled(event.target.checked)}
+                sx={{
+                  "& .MuiSwitch-switchBase.Mui-checked": {
+                    color: paletteQuery.accent
+                  },
+                  "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                    backgroundColor: paletteQuery.accent
+                  }
+                }}
+              />
+            }
+            label="Limit the number of answers"
+          />
+
+          <TextField
+            label="Answer limit"
+            type="number"
+            size="small"
+            value={maxAnswersLimit}
+            disabled={!limitAnswersEnabled}
+            error={limitValueInvalid}
+            helperText={
+              limitValueInvalid ? "Enter an integer greater than or equal to 1." : " "
+            }
+            onChange={(event) => {
+              const parsed = Number.parseInt(event.target.value, 10);
+              if (!Number.isNaN(parsed)) {
+                setMaxAnswersLimit(parsed);
+              }
+            }}
+            inputProps={{ min: 1, step: 1 }}
+            fullWidth
+            sx={fieldSx}
+          />
+        </ParameterLimitField>
+
+        <ParameterSwitchStack>
+          {BASE_QUERY_SWITCHES.map((item) => (
+            <FormControlLabel
+              key={item.key}
+              sx={switchSx}
+              labelPlacement="start"
+              control={
+                <Switch
+                  size="small"
+                  checked={switches[item.key]}
+                  onChange={(event) => updateSwitch(item.key, event.target.checked)}
+                  sx={{
+                    "& .MuiSwitch-switchBase.Mui-checked": {
+                      color: paletteQuery.accent
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                      backgroundColor: paletteQuery.accent
+                    }
+                  }}
+                />
+              }
+              label={item.label}
             />
-          }
-          label="Limit the number of answers"
-        />
+          ))}
+        </ParameterSwitchStack>
 
-        <TextField
-          label="Answer limit"
-          type="number"
-          size="small"
-          value={maxAnswersLimit}
-          disabled={!limitAnswersEnabled}
-          error={limitValueInvalid}
-          helperText={
-            limitValueInvalid ? "Enter an integer greater than or equal to 1." : " "
-          }
-          onChange={(event) => {
-            const parsed = Number.parseInt(event.target.value, 10);
-            if (!Number.isNaN(parsed)) {
-              setMaxAnswersLimit(parsed);
-            }
-          }}
-          inputProps={{ min: 1, step: 1 }}
+        <ParameterDivider />
+
+        <ParameterSwitchStack>
+          {QUERY_SWITCHES.map((item) => (
+            <FormControlLabel
+              key={item.key}
+              sx={switchSx}
+              labelPlacement="start"
+              control={
+                <Switch
+                  size="small"
+                  checked={switches[item.key]}
+                  onChange={(event) => updateSwitch(item.key, event.target.checked)}
+                  sx={{
+                    "& .MuiSwitch-switchBase.Mui-checked": {
+                      color: paletteQuery.accent
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                      backgroundColor: paletteQuery.accent
+                    }
+                  }}
+                />
+              }
+              label={item.label}
+            />
+          ))}
+        </ParameterSwitchStack>
+      </ParameterSectionBody>
+
+      <ParameterApplyFooter>
+        <ApplyParametersButton
+          variant="contained"
+          disableElevation
           fullWidth
-          sx={fieldSx}
-        />
-      </ParameterLimitField>
-
-      <ParameterSwitchStack>
-        {BASE_QUERY_SWITCHES.map((item) => (
-          <FormControlLabel
-            key={item.key}
-            sx={switchSx}
-            labelPlacement="start"
-            control={
-              <Switch
-                size="small"
-                checked={switches[item.key]}
-                onChange={(event) => updateSwitch(item.key, event.target.checked)}
-                sx={{
-                  "& .MuiSwitch-switchBase.Mui-checked": {
-                    color: paletteQuery.accent
-                  },
-                  "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
-                    backgroundColor: paletteQuery.accent
-                  }
-                }}
-              />
-            }
-            label={item.label}
-          />
-        ))}
-      </ParameterSwitchStack>
-
-      <ParameterDivider />
-
-      <ParameterSwitchStack>
-        {QUERY_SWITCHES.map((item) => (
-          <FormControlLabel
-            key={item.key}
-            sx={switchSx}
-            labelPlacement="start"
-            control={
-              <Switch
-                size="small"
-                checked={switches[item.key]}
-                onChange={(event) => updateSwitch(item.key, event.target.checked)}
-                sx={{
-                  "& .MuiSwitch-switchBase.Mui-checked": {
-                    color: paletteQuery.accent
-                  },
-                  "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
-                    backgroundColor: paletteQuery.accent
-                  }
-                }}
-              />
-            }
-            label={item.label}
-          />
-        ))}
-      </ParameterSwitchStack>
-    </ParameterSectionBody>
+          disabled={limitValueInvalid || isApplying}
+          onClick={handleApplyParameters}
+        >
+          {isApplying ? "Applying…" : "Apply parameters"}
+        </ApplyParametersButton>
+        {applyMessage ? (
+          <ParameterApplyMessage className={applyMessageType}>
+            {applyMessage}
+          </ParameterApplyMessage>
+        ) : null}
+      </ParameterApplyFooter>
+    </ParameterSectionRoot>
   );
 }

--- a/das-dashboard/src/components/query_page/ParameterSection.jsx
+++ b/das-dashboard/src/components/query_page/ParameterSection.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   FormControl,
   FormControlLabel,
@@ -11,11 +11,11 @@ import {
 } from "@mui/material";
 import { setQueryParameters } from "../../api/QueryAPI";
 import { extractErrorDetails } from "../../api/APIUtils";
-import { buildQueryParameters } from "../../utils/queryParameters";
+import { useToast } from "../global_providers/ToastProvider";
+import { useQueryParameters } from "../../hooks/useQueryParameters";
 import {
   ApplyParametersButton,
   ParameterApplyFooter,
-  ParameterApplyMessage,
   ParameterDivider,
   ParameterFieldGrid,
   ParameterLimitField,
@@ -73,40 +73,44 @@ const switchSx = {
   }
 };
 
-const INITIAL_SWITCH_STATE = Object.fromEntries(
-  [...BASE_QUERY_SWITCHES, ...QUERY_SWITCHES].map((item) => [item.key, false])
-);
-
 export default function ParameterSection() {
-  const [attentionUpdate, setAttentionUpdate] = useState(0);
-  const [attentionCorrelation, setAttentionCorrelation] = useState(0);
-  const [attentionFocusStrictness, setAttentionFocusStrictness] = useState(0);
-  const [maxBundleSize, setMaxBundleSize] = useState(1000);
-  const [limitAnswersEnabled, setLimitAnswersEnabled] = useState(false);
-  const [maxAnswersLimit, setMaxAnswersLimit] = useState(1);
-  const [switches, setSwitches] = useState(INITIAL_SWITCH_STATE);
+  const {
+    attentionUpdate,
+    setAttentionUpdate,
+    attentionCorrelation,
+    setAttentionCorrelation,
+    attentionFocusStrictness,
+    setAttentionFocusStrictness,
+    maxBundleSize,
+    setMaxBundleSize,
+    limitAnswersEnabled,
+    setLimitAnswersEnabled,
+    maxAnswersLimit,
+    setMaxAnswersLimit,
+    switches,
+    updateSwitch,
+    collectParameters,
+    markParametersApplied
+  } = useQueryParameters();
+
+  const { showToast } = useToast();
   const [isApplying, setIsApplying] = useState(false);
-  const [applyMessage, setApplyMessage] = useState(null);
-  const [applyMessageType, setApplyMessageType] = useState(null);
+
+  useEffect(() => {
+    if (!isApplying) {
+      return undefined;
+    }
+
+    document.body.style.cursor = "wait";
+
+    return () => {
+      document.body.style.cursor = "";
+    };
+  }, [isApplying]);
 
   const limitValueInvalid =
     limitAnswersEnabled &&
     (!Number.isInteger(maxAnswersLimit) || maxAnswersLimit < 1);
-
-  const updateSwitch = (key, checked) => {
-    setSwitches((previous) => ({ ...previous, [key]: checked }));
-  };
-
-  const collectParameters = () =>
-    buildQueryParameters({
-      attentionUpdate,
-      attentionCorrelation,
-      attentionFocusStrictness,
-      maxBundleSize,
-      limitAnswersEnabled,
-      maxAnswersLimit,
-      switches
-    });
 
   const handleApplyParameters = async () => {
     if (limitValueInvalid || isApplying) {
@@ -114,16 +118,18 @@ export default function ParameterSection() {
     }
 
     setIsApplying(true);
-    setApplyMessage(null);
-    setApplyMessageType(null);
 
     try {
-      await setQueryParameters(collectParameters());
-      setApplyMessage("Parameters applied.");
-      setApplyMessageType("success");
+      const params = collectParameters();
+      await setQueryParameters(params);
+      markParametersApplied(params);
+      showToast({ message: "Query parameters applied.", severity: "success" });
     } catch (error) {
-      setApplyMessage(extractErrorDetails(error));
-      setApplyMessageType("error");
+      showToast({
+        message: "Failed to apply query parameters.",
+        severity: "error",
+        details: extractErrorDetails(error)
+      });
     } finally {
       setIsApplying(false);
     }
@@ -304,11 +310,6 @@ export default function ParameterSection() {
         >
           {isApplying ? "Applying…" : "Apply parameters"}
         </ApplyParametersButton>
-        {applyMessage ? (
-          <ParameterApplyMessage className={applyMessageType}>
-            {applyMessage}
-          </ParameterApplyMessage>
-        ) : null}
       </ParameterApplyFooter>
     </ParameterSectionRoot>
   );

--- a/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
+++ b/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { getQueryAnswers } from "../../api/QueryAPI";
 import { extractErrorDetails } from "../../api/APIUtils";
+import { formatQueryAnswer } from "../../utils/formatQueryAnswer";
 import {
   AllAnswersList,
   AllAnswersModalPaper,
@@ -32,11 +33,7 @@ function toPage(answers, page) {
     page_size: PAGE_SIZE,
     total,
     total_pages: total > 0 ? Math.ceil(total / PAGE_SIZE) : 0,
-    items: answers.slice(start, start + PAGE_SIZE).map((answer) => ({
-      id: answer.id,
-      response: answer.response,
-      importance: answer.importance
-    }))
+    items: answers.slice(start, start + PAGE_SIZE)
   };
 }
 
@@ -153,7 +150,7 @@ export default function QueryAllAnswersModal({
             {items.map((answer) => (
               <ResultRow key={answer.id}>
                 <ResultAccent />
-                <ResultText>{answer.response}</ResultText>
+                <ResultText>{answer.label ?? formatQueryAnswer(answer)}</ResultText>
               </ResultRow>
             ))}
           </AllAnswersList>

--- a/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
+++ b/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { getQueryAnswers } from "../../api/QueryAPI";
 import { extractErrorDetails } from "../../api/APIUtils";
+import { useQueryParameters } from "../../hooks/useQueryParameters";
 import { formatQueryAnswer } from "../../utils/formatQueryAnswer";
 import {
   AllAnswersList,
@@ -47,6 +48,12 @@ export default function QueryAllAnswersModal({
   const [pageData, setPageData] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { switches } = useQueryParameters();
+  const displayOptions = {
+    preferMetta: Boolean(
+      switches.populate_metta_mapping || switches.use_metta_as_query_tokens
+    )
+  };
 
   useEffect(() => {
     if (!open) {
@@ -150,7 +157,9 @@ export default function QueryAllAnswersModal({
             {items.map((answer) => (
               <ResultRow key={answer.id}>
                 <ResultAccent />
-                <ResultText>{answer.label ?? formatQueryAnswer(answer)}</ResultText>
+                <ResultText>
+                  {answer.label ?? formatQueryAnswer(answer, displayOptions)}
+                </ResultText>
               </ResultRow>
             ))}
           </AllAnswersList>

--- a/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
+++ b/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Box,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Pagination,
+  Typography
+} from "@mui/material";
+import { getQueryAnswers } from "../../api/QueryAPI";
+import { extractErrorDetails } from "../../api/APIUtils";
+import {
+  AllAnswersList,
+  AllAnswersModalPaper,
+  ResultAccent,
+  ResultRow,
+  ResultText,
+  paletteQuery
+} from "../../pages/query/querypage.styled";
+
+const PAGE_SIZE = 10;
+
+function toPage(answers, page) {
+  const total = answers.length;
+  const start = (page - 1) * PAGE_SIZE;
+
+  return {
+    page,
+    page_size: PAGE_SIZE,
+    total,
+    total_pages: total > 0 ? Math.ceil(total / PAGE_SIZE) : 0,
+    items: answers.slice(start, start + PAGE_SIZE).map((answer) => ({
+      id: answer.id,
+      response: answer.response,
+      importance: answer.importance
+    }))
+  };
+}
+
+export default function QueryAllAnswersModal({
+  open,
+  onClose,
+  executionId,
+  answers = []
+}) {
+  const [page, setPage] = useState(1);
+  const [pageData, setPageData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!open) {
+      setPage(1);
+      setPageData(null);
+      setError(null);
+      setIsLoading(false);
+      return undefined;
+    }
+
+    if (!executionId) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    getQueryAnswers(executionId, page, PAGE_SIZE)
+      .then((response) => {
+        if (cancelled) {
+          return;
+        }
+
+        setPageData(response.total > 0 ? response : toPage(answers, page));
+      })
+      .catch((loadError) => {
+        if (cancelled) {
+          return;
+        }
+
+        if (answers.length > 0) {
+          setPageData(toPage(answers, page));
+          return;
+        }
+
+        setError(extractErrorDetails(loadError));
+        setPageData(null);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, executionId, page, answers]);
+
+  const total = pageData?.total ?? 0;
+  const totalPages = pageData?.total_pages ?? 0;
+  const items = pageData?.items ?? [];
+
+  const pageLabel =
+    total === 0
+      ? "No answers yet"
+      : `Showing ${(page - 1) * PAGE_SIZE + 1}-${Math.min(page * PAGE_SIZE, total)} of ${total}`;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="md"
+      PaperProps={{ sx: AllAnswersModalPaper }}
+    >
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          pr: 1.5,
+          fontSize: 16,
+          fontWeight: 600,
+          color: paletteQuery.textPrimary
+        }}
+      >
+        All answers
+        <IconButton aria-label="Close" onClick={onClose} size="small">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 0 }}>
+        <Typography sx={{ fontSize: 12, color: paletteQuery.textSecondary, mb: 2 }}>
+          {pageLabel}
+        </Typography>
+
+        {isLoading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : error ? (
+          <Typography sx={{ fontSize: 13, color: paletteQuery.danger, py: 4 }}>
+            {error}
+          </Typography>
+        ) : items.length > 0 ? (
+          <AllAnswersList>
+            {items.map((answer) => (
+              <ResultRow key={answer.id}>
+                <ResultAccent />
+                <ResultText>{answer.response}</ResultText>
+              </ResultRow>
+            ))}
+          </AllAnswersList>
+        ) : (
+          <Typography sx={{ fontSize: 13, color: paletteQuery.textMuted, py: 4 }}>
+            No answers to display.
+          </Typography>
+        )}
+
+        {totalPages > 1 ? (
+          <Box sx={{ display: "flex", justifyContent: "center", pt: 2 }}>
+            <Pagination
+              count={totalPages}
+              page={page}
+              onChange={(_, nextPage) => setPage(nextPage)}
+              size="small"
+              color="primary"
+            />
+          </Box>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
+++ b/das-dashboard/src/components/query_page/QueryAllAnswersModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CloseIcon from "@mui/icons-material/Close";
 import {
   Box,
@@ -55,6 +55,9 @@ export default function QueryAllAnswersModal({
     )
   };
 
+  const answersRef = useRef(answers);
+  answersRef.current = answers;
+
   useEffect(() => {
     if (!open) {
       setPage(1);
@@ -78,15 +81,15 @@ export default function QueryAllAnswersModal({
           return;
         }
 
-        setPageData(response.total > 0 ? response : toPage(answers, page));
+        setPageData(response.total > 0 ? response : toPage(answersRef.current, page));
       })
       .catch((loadError) => {
         if (cancelled) {
           return;
         }
 
-        if (answers.length > 0) {
-          setPageData(toPage(answers, page));
+        if (answersRef.current.length > 0) {
+          setPageData(toPage(answersRef.current, page));
           return;
         }
 
@@ -102,7 +105,7 @@ export default function QueryAllAnswersModal({
     return () => {
       cancelled = true;
     };
-  }, [open, executionId, page, answers]);
+  }, [open, executionId, page]);
 
   const total = pageData?.total ?? 0;
   const totalPages = pageData?.total_pages ?? 0;
@@ -119,7 +122,7 @@ export default function QueryAllAnswersModal({
       onClose={onClose}
       fullWidth
       maxWidth="md"
-      PaperProps={{ sx: AllAnswersModalPaper }}
+      slotProps={{ paper: { sx: AllAnswersModalPaper } }}
     >
       <DialogTitle
         sx={{

--- a/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
+++ b/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
@@ -1,0 +1,64 @@
+import {
+  EmptyPanelState,
+  PanelHeader,
+  PanelMeta,
+  PanelTitle,
+  QueryResultsCard,
+  ResultAccent,
+  ResultRow,
+  ResultText,
+  ResultsFooter,
+  ResultsFooterLink,
+  ResultsList,
+  StreamingHint
+} from "../../pages/query/querypage.styled";
+
+const PREVIEW_LIMIT = 5;
+
+export default function QueryAnswersPanel({
+  answers,
+  isRunning,
+  previewLimit = PREVIEW_LIMIT
+}) {
+  const previewAnswers = answers.slice(-previewLimit);
+
+  return (
+    <QueryResultsCard>
+      <PanelHeader>
+        <PanelTitle>Results</PanelTitle>
+        <PanelMeta>MeTTa expression</PanelMeta>
+      </PanelHeader>
+
+      {previewAnswers.length === 0 ? (
+        <EmptyPanelState>
+          {isRunning
+            ? "Waiting for the first answer…"
+            : "Run a query to stream answers here."}
+        </EmptyPanelState>
+      ) : (
+        <>
+          <ResultsList>
+            {previewAnswers.map((answer) => (
+              <ResultRow key={answer.id}>
+                <ResultAccent />
+                <ResultText>{answer.text}</ResultText>
+              </ResultRow>
+            ))}
+          </ResultsList>
+
+          {answers.length > previewLimit && (
+            <ResultsFooter>
+              <ResultsFooterLink>
+                View all {answers.length} answers
+              </ResultsFooterLink>
+            </ResultsFooter>
+          )}
+
+          {isRunning && (
+            <StreamingHint>Streaming more answers…</StreamingHint>
+          )}
+        </>
+      )}
+    </QueryResultsCard>
+  );
+}

--- a/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
+++ b/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
@@ -1,3 +1,6 @@
+import { useState } from "react";
+import { Box } from "@mui/material";
+import QueryAllAnswersModal from "./QueryAllAnswersModal";
 import {
   EmptyPanelState,
   PanelHeader,
@@ -7,58 +10,81 @@ import {
   ResultAccent,
   ResultRow,
   ResultText,
-  ResultsFooter,
-  ResultsFooterLink,
   ResultsList,
   StreamingHint
 } from "../../pages/query/querypage.styled";
 
-const PREVIEW_LIMIT = 5;
+const RESULT_LIMIT = 10;
 
 export default function QueryAnswersPanel({
   answers,
+  executionId,
   isRunning,
-  previewLimit = PREVIEW_LIMIT
+  isCountOnly = false,
+  totalAnswers,
+  resultLimit = RESULT_LIMIT
 }) {
-  const previewAnswers = answers.slice(-previewLimit);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const visibleAnswers = answers.slice(-resultLimit);
+  const answerTotal = totalAnswers ?? answers.length;
+  const canShowAll = Boolean(executionId) && answerTotal > 0;
 
   return (
-    <QueryResultsCard>
-      <PanelHeader>
-        <PanelTitle>Results</PanelTitle>
-        <PanelMeta>MeTTa expression</PanelMeta>
-      </PanelHeader>
+    <>
+      <QueryResultsCard>
+        <PanelHeader>
+          <PanelTitle>Results</PanelTitle>
+          <Box sx={{ display: "flex", gap: "10px" }}>
+            <PanelMeta>
+              {answerTotal > 0
+                ? `• Last ${Math.min(resultLimit, visibleAnswers.length)} of ${answerTotal}`
+                : "MeTTa expression"}
+            </PanelMeta>
+            {canShowAll ? (
+              <PanelMeta
+                sx={{ textDecoration: "underline", cursor: "pointer" }}
+                onClick={() => setIsModalOpen(true)}
+              >
+                Show all results
+              </PanelMeta>
+            ) : null}
+          </Box>
+        </PanelHeader>
 
-      {previewAnswers.length === 0 ? (
-        <EmptyPanelState>
-          {isRunning
-            ? "Waiting for the first answer…"
-            : "Run a query to stream answers here."}
-        </EmptyPanelState>
-      ) : (
-        <>
-          <ResultsList>
-            {previewAnswers.map((answer) => (
-              <ResultRow key={answer.id}>
-                <ResultAccent />
-                <ResultText>{answer.text}</ResultText>
-              </ResultRow>
-            ))}
-          </ResultsList>
+        {visibleAnswers.length === 0 ? (
+          <EmptyPanelState>
+            {isRunning
+              ? isCountOnly
+                ? "Waiting for the count result…"
+                : "Waiting for the first answer…"
+              : isCountOnly
+                ? "Run a count-only query to see the total here."
+                : "Run a query to stream answers here."}
+          </EmptyPanelState>
+        ) : (
+          <>
+            <ResultsList>
+              {visibleAnswers.map((answer) => (
+                <ResultRow key={answer.id}>
+                  <ResultAccent />
+                  <ResultText>{answer.response}</ResultText>
+                </ResultRow>
+              ))}
+            </ResultsList>
 
-          {answers.length > previewLimit && (
-            <ResultsFooter>
-              <ResultsFooterLink>
-                View all {answers.length} answers
-              </ResultsFooterLink>
-            </ResultsFooter>
-          )}
+            {isRunning ? (
+              <StreamingHint>Streaming more answers…</StreamingHint>
+            ) : null}
+          </>
+        )}
+      </QueryResultsCard>
 
-          {isRunning && (
-            <StreamingHint>Streaming more answers…</StreamingHint>
-          )}
-        </>
-      )}
-    </QueryResultsCard>
+      <QueryAllAnswersModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        executionId={executionId}
+        answers={answers}
+      />
+    </>
   );
 }

--- a/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
+++ b/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
@@ -38,7 +38,7 @@ export default function QueryAnswersPanel({
             <PanelMeta>
               {answerTotal > 0
                 ? `• Last ${Math.min(resultLimit, visibleAnswers.length)} of ${answerTotal}`
-                : "MeTTa expression"}
+                : "No answers yet"}
             </PanelMeta>
             {canShowAll ? (
               <PanelMeta

--- a/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
+++ b/das-dashboard/src/components/query_page/QueryAnswersPanel.jsx
@@ -67,7 +67,7 @@ export default function QueryAnswersPanel({
               {visibleAnswers.map((answer) => (
                 <ResultRow key={answer.id}>
                   <ResultAccent />
-                  <ResultText>{answer.response}</ResultText>
+                  <ResultText>{answer.label}</ResultText>
                 </ResultRow>
               ))}
             </ResultsList>

--- a/das-dashboard/src/components/query_page/QueryFrequencyHistogram.jsx
+++ b/das-dashboard/src/components/query_page/QueryFrequencyHistogram.jsx
@@ -19,7 +19,7 @@ export default function QueryFrequencyHistogram({ histogram }) {
       <PanelHeader>
         <PanelTitle>Answer frequency</PanelTitle>
         <PanelMeta>
-          {histogram.scaleLabel} · {BUCKET_COUNT} buckets
+          Answers in the last {histogram.scaleLabel}
         </PanelMeta>
       </PanelHeader>
 

--- a/das-dashboard/src/components/query_page/QueryFrequencyHistogram.jsx
+++ b/das-dashboard/src/components/query_page/QueryFrequencyHistogram.jsx
@@ -1,0 +1,72 @@
+import { BarChart } from "@mui/x-charts/BarChart";
+import {
+  AnswerHistogramCard,
+  EmptyPanelState,
+  HistogramBody,
+  PanelHeader,
+  PanelMeta,
+  PanelTitle,
+  paletteQuery
+} from "../../pages/query/querypage.styled";
+
+const BUCKET_COUNT = 30;
+
+export default function QueryFrequencyHistogram({ histogram }) {
+  const hasData = histogram.counts.some((count) => count > 0);
+
+  return (
+    <AnswerHistogramCard>
+      <PanelHeader>
+        <PanelTitle>Answer frequency</PanelTitle>
+        <PanelMeta>
+          {histogram.scaleLabel} · {BUCKET_COUNT} buckets
+        </PanelMeta>
+      </PanelHeader>
+
+      <HistogramBody>
+        {hasData ? (
+          <BarChart
+            height={260}
+            series={[
+              {
+                data: histogram.counts,
+                label: "Answers",
+                color: paletteQuery.accent,
+                id: "answers"
+              }
+            ]}
+            xAxis={[
+              {
+                data: histogram.labels,
+                scaleType: "band",
+                tickLabelStyle: { display: "none" }
+              }
+            ]}
+            yAxis={[
+              {
+                min: 0,
+                max: histogram.maxCount,
+                tickMinStep: 1,
+                label: "Answers",
+                tickLabelStyle: {
+                  fontSize: 11,
+                  fill: paletteQuery.textSecondary
+                }
+              }
+            ]}
+            margin={{ left: 48, right: 16, top: 24, bottom: 36 }}
+            slotProps={{ legend: { hidden: true } }}
+            grid={{ horizontal: true }}
+            borderRadius={3}
+            skipAnimation
+          />
+        ) : (
+          <EmptyPanelState>
+            Frequency timeline fills as answers arrive within the current{" "}
+            {histogram.scaleLabel} window.
+          </EmptyPanelState>
+        )}
+      </HistogramBody>
+    </AnswerHistogramCard>
+  );
+}

--- a/das-dashboard/src/components/query_page/QueryImportanceChart.jsx
+++ b/das-dashboard/src/components/query_page/QueryImportanceChart.jsx
@@ -1,0 +1,87 @@
+import { BarChart } from "@mui/x-charts/BarChart";
+import {
+  AnswerHistogramCard,
+  EmptyPanelState,
+  HistogramBody,
+  PanelHeader,
+  PanelMeta,
+  PanelTitle,
+  paletteQuery
+} from "../../pages/query/querypage.styled";
+
+const EMPTY_CHART = {
+  values: [],
+  labels: [],
+  maxValue: 1,
+  nonZeroCount: 0
+};
+
+export default function QueryImportanceChart({ chart = EMPTY_CHART }) {
+  const hasData = chart.values.length > 0;
+
+  return (
+    <AnswerHistogramCard>
+      <PanelHeader>
+        <PanelTitle>Answer importance (STI)</PanelTitle>
+        <PanelMeta>
+          {hasData
+            ? `${chart.nonZeroCount} non-zero · scale 0–1`
+            : "Short-term importance per answer"}
+        </PanelMeta>
+      </PanelHeader>
+
+      <HistogramBody>
+        {hasData ? (
+          <BarChart
+            height={260}
+            series={[
+              {
+                data: chart.values,
+                label: "STI",
+                color: paletteQuery.accent,
+                id: "sti"
+              }
+            ]}
+            xAxis={[
+              {
+                data: chart.labels,
+                scaleType: "band",
+                tickLabelStyle: {
+                  fontSize: 10,
+                  fill: paletteQuery.textSecondary,
+                  angle: chart.labels.length > 6 ? -35 : 0,
+                  textAnchor: chart.labels.length > 6 ? "end" : "middle"
+                }
+              }
+            ]}
+            yAxis={[
+              {
+                min: 0,
+                max: chart.maxValue,
+                label: "STI",
+                tickLabelStyle: {
+                  fontSize: 11,
+                  fill: paletteQuery.textSecondary
+                }
+              }
+            ]}
+            margin={{
+              left: 48,
+              right: 16,
+              top: 24,
+              bottom: chart.labels.length > 6 ? 56 : 40
+            }}
+            slotProps={{ legend: { hidden: true } }}
+            grid={{ horizontal: true }}
+            borderRadius={3}
+            skipAnimation
+          />
+        ) : (
+          <EmptyPanelState>
+            STI values from each answer will appear here once a query is run.
+          </EmptyPanelState>
+        )}
+      </HistogramBody>
+    </AnswerHistogramCard>
+  );
+}

--- a/das-dashboard/src/components/query_page/QueryStatusBar.jsx
+++ b/das-dashboard/src/components/query_page/QueryStatusBar.jsx
@@ -1,0 +1,67 @@
+import {
+  GeneralStatusBar,
+  StatusDivider,
+  StatusDot,
+  StatusMetric,
+  StatusMetricLabel,
+  StatusMetricValue,
+  StatusMetrics,
+  StatusPill
+} from "../../pages/query/querypage.styled";
+
+export default function QueryStatusBar({
+  status,
+  answerCount,
+  elapsedLabel,
+  answersPerSecond,
+  queryId
+}) {
+  return (
+    <GeneralStatusBar>
+      <StatusPill tone={status}>
+        <StatusDot tone={status} />
+        {status}
+      </StatusPill>
+
+      <StatusDivider />
+
+      <StatusMetrics>
+        <StatusMetric>
+          <StatusMetricLabel>Answers</StatusMetricLabel>
+          <StatusMetricValue>{answerCount}</StatusMetricValue>
+        </StatusMetric>
+
+        <StatusDivider />
+
+        <StatusMetric>
+          <StatusMetricLabel>Elapsed</StatusMetricLabel>
+          <StatusMetricValue>{elapsedLabel}</StatusMetricValue>
+        </StatusMetric>
+
+        <StatusDivider />
+
+        <StatusMetric>
+          <StatusMetricLabel>Retrieved</StatusMetricLabel>
+          <StatusMetricValue>{answerCount}</StatusMetricValue>
+        </StatusMetric>
+
+        <StatusDivider />
+
+        <StatusMetric>
+          <StatusMetricLabel>Rate</StatusMetricLabel>
+          <StatusMetricValue>{answersPerSecond.toFixed(1)} ans/s</StatusMetricValue>
+        </StatusMetric>
+
+        {queryId != null && (
+          <>
+            <StatusDivider />
+            <StatusMetric>
+              <StatusMetricLabel>Query ID</StatusMetricLabel>
+              <StatusMetricValue>#{queryId}</StatusMetricValue>
+            </StatusMetric>
+          </>
+        )}
+      </StatusMetrics>
+    </GeneralStatusBar>
+  );
+}

--- a/das-dashboard/src/components/query_page/QueryStatusBar.jsx
+++ b/das-dashboard/src/components/query_page/QueryStatusBar.jsx
@@ -10,24 +10,24 @@ import {
 } from "../../pages/query/querypage.styled";
 
 export default function QueryStatusBar({
-  status,
+  isRunning,
   answerCount,
   elapsedLabel,
-  answersPerSecond,
-  queryId
+  executionId,
+  isCountOnly = false
 }) {
   return (
     <GeneralStatusBar>
-      <StatusPill tone={status}>
-        <StatusDot tone={status} />
-        {status}
+      <StatusPill tone={isRunning ? "running" : "idle"}>
+        <StatusDot tone={isRunning ? "running" : "idle"} />
+        {isRunning ? "Running" : "Running"}
       </StatusPill>
 
       <StatusDivider />
 
       <StatusMetrics>
         <StatusMetric>
-          <StatusMetricLabel>Answers</StatusMetricLabel>
+          <StatusMetricLabel>{isCountOnly ? "Count" : "Answers"}</StatusMetricLabel>
           <StatusMetricValue>{answerCount}</StatusMetricValue>
         </StatusMetric>
 
@@ -41,23 +41,16 @@ export default function QueryStatusBar({
         <StatusDivider />
 
         <StatusMetric>
-          <StatusMetricLabel>Retrieved</StatusMetricLabel>
+          <StatusMetricLabel>{isCountOnly ? "Total" : "Retrieved"}</StatusMetricLabel>
           <StatusMetricValue>{answerCount}</StatusMetricValue>
         </StatusMetric>
 
-        <StatusDivider />
-
-        <StatusMetric>
-          <StatusMetricLabel>Rate</StatusMetricLabel>
-          <StatusMetricValue>{answersPerSecond.toFixed(1)} ans/s</StatusMetricValue>
-        </StatusMetric>
-
-        {queryId != null && (
+        {executionId != null && (
           <>
             <StatusDivider />
             <StatusMetric>
               <StatusMetricLabel>Query ID</StatusMetricLabel>
-              <StatusMetricValue>#{queryId}</StatusMetricValue>
+              <StatusMetricValue>#{executionId.slice(0, 8)}</StatusMetricValue>
             </StatusMetric>
           </>
         )}

--- a/das-dashboard/src/components/top_nav_bar/NavBar.jsx
+++ b/das-dashboard/src/components/top_nav_bar/NavBar.jsx
@@ -30,7 +30,7 @@ const AppBarItem = styled("a")({
   },
 });
 
-export default function Navbar() {
+export default function NavBar() {
   return (
     <MainAppBar position="static" elevation={0}>
       <StyledToolbar>
@@ -43,6 +43,7 @@ export default function Navbar() {
           <AppBarItem href="/profiles">Profile</AppBarItem>
           <AppBarItem href="/configuration">Configuration</AppBarItem>
           <AppBarItem href="/dashboard">Dashboard</AppBarItem>
+          <AppBarItem href="/query">Query</AppBarItem>
         </AppBarItems>
 
       </StyledToolbar>

--- a/das-dashboard/src/hooks/useQueryExecution.js
+++ b/das-dashboard/src/hooks/useQueryExecution.js
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   cancelQueryExecution,
-  getQueryExecutionStatus,
   setQueryParameters,
   startQueryExecution
 } from "../api/QueryAPI";
 import { extractErrorDetails } from "../api/APIUtils";
 import { createQueryExecutionStream } from "../api/QueryStreamService";
 import { buildFrequencyHistogram, buildStiChart } from "../utils/queryCharts";
+import { formatQueryAnswer } from "../utils/formatQueryAnswer";
 
 const TERMINAL_STATUSES = new Set(["completed", "aborted", "error"]);
 
@@ -63,8 +63,10 @@ export function useQueryExecution(parameters) {
       answerSeqRef.current += 1;
       return {
         id: answerSeqRef.current,
-        response: item.response ?? "",
+        ...item,
+        label: formatQueryAnswer(item),
         importance: Number(item.importance ?? 0),
+        strength: Number(item.strength ?? 0),
         receivedAt: receivedAt + index
       };
     });
@@ -77,7 +79,9 @@ export function useQueryExecution(parameters) {
     setAnswers([
       {
         id: answerSeqRef.current,
-        response: `Returned ${count} answers`,
+        count_only: true,
+        count: Number(count),
+        label: `Returned ${count} answers`,
         importance: 0,
         receivedAt: Date.now()
       }
@@ -85,7 +89,7 @@ export function useQueryExecution(parameters) {
     setAnswerCount(Number(count));
   }, []);
 
-  const finishExecution = useCallback(async (event) => {
+  const finishExecution = useCallback((event) => {
     closeStream();
     startedAtRef.current = null;
     setIsRunning(false);
@@ -94,32 +98,20 @@ export function useQueryExecution(parameters) {
       setStreamError(event.message);
     }
 
-    const isCountOnlyQuery =
-      isCountOnlyRef.current &&
-      event?.status === "completed" &&
-      executionIdRef.current;
-
-    if (isCountOnlyQuery) {
-      try {
-        const status = await getQueryExecutionStatus(executionIdRef.current);
-        const count = status.total_items ?? status.received_count;
-        if (typeof count === "number") {
-          showCountResult(count);
-        }
-      } catch (error) {
-        setStreamError(extractErrorDetails(error));
-      }
-      return;
-    }
-
-    if (typeof event?.received_count === "number") {
+    if (typeof event?.received_count === "number" && !isCountOnlyRef.current) {
       setAnswerCount(event.received_count);
     }
-  }, [closeStream, showCountResult]);
+  }, [closeStream]);
 
   const handleStreamEvent = useCallback(
     (event) => {
-      if (event?.type === "chunk" && !isCountOnlyRef.current) {
+      if (event?.type === "chunk") {
+        const countItem = event.data?.find((item) => item?.count_only);
+        if (countItem) {
+          showCountResult(countItem.count);
+          return;
+        }
+
         appendAnswersFromChunk(event.data, event.received_count);
         return;
       }
@@ -133,7 +125,7 @@ export function useQueryExecution(parameters) {
         void finishExecution(event);
       }
     },
-    [appendAnswersFromChunk, finishExecution]
+    [appendAnswersFromChunk, finishExecution, showCountResult]
   );
 
   const connectStream = useCallback(

--- a/das-dashboard/src/hooks/useQueryExecution.js
+++ b/das-dashboard/src/hooks/useQueryExecution.js
@@ -49,30 +49,39 @@ export function useQueryExecution(parameters) {
     setExecutionId(null);
   }, [closeStream]);
 
-  const appendAnswersFromChunk = useCallback((chunkItems, receivedCount) => {
-    if (typeof receivedCount === "number") {
-      setAnswerCount(receivedCount);
-    }
+  const preferMettaDisplay = Boolean(
+    parameters.switches?.populate_metta_mapping ||
+      parameters.switches?.use_metta_as_query_tokens
+  );
 
-    if (!Array.isArray(chunkItems) || chunkItems.length === 0) {
-      return;
-    }
+  const appendAnswersFromChunk = useCallback(
+    (chunkItems, receivedCount) => {
+      if (typeof receivedCount === "number") {
+        setAnswerCount(receivedCount);
+      }
 
-    const receivedAt = Date.now();
-    const nextAnswers = chunkItems.map((item, index) => {
-      answerSeqRef.current += 1;
-      return {
-        id: answerSeqRef.current,
-        ...item,
-        label: formatQueryAnswer(item),
-        importance: Number(item.importance ?? 0),
-        strength: Number(item.strength ?? 0),
-        receivedAt: receivedAt + index
-      };
-    });
+      if (!Array.isArray(chunkItems) || chunkItems.length === 0) {
+        return;
+      }
 
-    setAnswers((previous) => [...previous, ...nextAnswers]);
-  }, []);
+      const receivedAt = Date.now();
+      const displayOptions = { preferMetta: preferMettaDisplay };
+      const nextAnswers = chunkItems.map((item, index) => {
+        answerSeqRef.current += 1;
+        return {
+          id: answerSeqRef.current,
+          ...item,
+          label: formatQueryAnswer(item, displayOptions),
+          importance: Number(item.importance ?? 0),
+          strength: Number(item.strength ?? 0),
+          receivedAt: receivedAt + index
+        };
+      });
+
+      setAnswers((previous) => [...previous, ...nextAnswers]);
+    },
+    [preferMettaDisplay]
+  );
 
   const showCountResult = useCallback((count) => {
     answerSeqRef.current += 1;

--- a/das-dashboard/src/hooks/useQueryExecution.js
+++ b/das-dashboard/src/hooks/useQueryExecution.js
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  cancelQueryExecution,
+  getQueryExecutionStatus,
+  setQueryParameters,
+  startQueryExecution
+} from "../api/QueryAPI";
+import { extractErrorDetails } from "../api/APIUtils";
+import { createQueryExecutionStream } from "../api/QueryStreamService";
+import { buildFrequencyHistogram, buildStiChart } from "../utils/queryCharts";
+
+const TERMINAL_STATUSES = new Set(["completed", "aborted", "error"]);
+
+function formatElapsedLabel(elapsedMs) {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function useQueryExecution(parameters) {
+  const [answers, setAnswers] = useState([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [executionId, setExecutionId] = useState(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [streamError, setStreamError] = useState(null);
+  const [answerCount, setAnswerCount] = useState(0);
+  const [isCountOnly, setIsCountOnly] = useState(false);
+
+  const streamRef = useRef(null);
+  const startedAtRef = useRef(null);
+  const answerSeqRef = useRef(0);
+  const executionIdRef = useRef(null);
+  const isCountOnlyRef = useRef(false);
+
+  const closeStream = useCallback(() => {
+    streamRef.current?.close();
+    streamRef.current = null;
+  }, []);
+
+  const resetSession = useCallback(() => {
+    closeStream();
+    setStreamError(null);
+    setAnswers([]);
+    setAnswerCount(0);
+    setElapsedMs(0);
+    answerSeqRef.current = 0;
+    executionIdRef.current = null;
+    setExecutionId(null);
+  }, [closeStream]);
+
+  const appendAnswersFromChunk = useCallback((chunkItems, receivedCount) => {
+    if (typeof receivedCount === "number") {
+      setAnswerCount(receivedCount);
+    }
+
+    if (!Array.isArray(chunkItems) || chunkItems.length === 0) {
+      return;
+    }
+
+    const receivedAt = Date.now();
+    const nextAnswers = chunkItems.map((item, index) => {
+      answerSeqRef.current += 1;
+      return {
+        id: answerSeqRef.current,
+        response: item.response ?? "",
+        importance: Number(item.importance ?? 0),
+        receivedAt: receivedAt + index
+      };
+    });
+
+    setAnswers((previous) => [...previous, ...nextAnswers]);
+  }, []);
+
+  const showCountResult = useCallback((count) => {
+    answerSeqRef.current += 1;
+    setAnswers([
+      {
+        id: answerSeqRef.current,
+        response: `Returned ${count} answers`,
+        importance: 0,
+        receivedAt: Date.now()
+      }
+    ]);
+    setAnswerCount(Number(count));
+  }, []);
+
+  const finishExecution = useCallback(async (event) => {
+    closeStream();
+    startedAtRef.current = null;
+    setIsRunning(false);
+
+    if (event?.message) {
+      setStreamError(event.message);
+    }
+
+    const isCountOnlyQuery =
+      isCountOnlyRef.current &&
+      event?.status === "completed" &&
+      executionIdRef.current;
+
+    if (isCountOnlyQuery) {
+      try {
+        const status = await getQueryExecutionStatus(executionIdRef.current);
+        const count = status.total_items ?? status.received_count;
+        if (typeof count === "number") {
+          showCountResult(count);
+        }
+      } catch (error) {
+        setStreamError(extractErrorDetails(error));
+      }
+      return;
+    }
+
+    if (typeof event?.received_count === "number") {
+      setAnswerCount(event.received_count);
+    }
+  }, [closeStream, showCountResult]);
+
+  const handleStreamEvent = useCallback(
+    (event) => {
+      if (event?.type === "chunk" && !isCountOnlyRef.current) {
+        appendAnswersFromChunk(event.data, event.received_count);
+        return;
+      }
+
+      if (event?.status === "running") {
+        setIsRunning(true);
+        return;
+      }
+
+      if (TERMINAL_STATUSES.has(event?.status)) {
+        void finishExecution(event);
+      }
+    },
+    [appendAnswersFromChunk, finishExecution]
+  );
+
+  const connectStream = useCallback(
+    (nextExecutionId) => {
+      closeStream();
+      executionIdRef.current = nextExecutionId;
+
+      streamRef.current = createQueryExecutionStream(nextExecutionId, {
+        onEvent: handleStreamEvent,
+        onError: (error) => {
+          setStreamError(error.message);
+          setIsRunning(false);
+        },
+        onClose: () => {
+          streamRef.current = null;
+        }
+      });
+    },
+    [closeStream, handleStreamEvent]
+  );
+
+  const startQuery = useCallback(
+    async (queryText) => {
+      const trimmedQuery = queryText.trim();
+      if (!trimmedQuery) {
+        return;
+      }
+
+      isCountOnlyRef.current = parameters.isCountOnly;
+      setIsCountOnly(parameters.isCountOnly);
+      resetSession();
+      setIsRunning(true);
+      startedAtRef.current = Date.now();
+
+      try {
+        const params = {
+          ...parameters.collectParameters(),
+          use_metta_as_query_tokens: true,
+          populate_metta_mapping: true
+        };
+
+        if (parameters.needsParameterApply(params)) {
+          await setQueryParameters(params);
+          parameters.markParametersApplied(params);
+        }
+
+        const { execution_id: nextExecutionId } = await startQueryExecution(trimmedQuery);
+        if (!nextExecutionId) {
+          throw new Error("Query execution did not return an execution id.");
+        }
+
+        setExecutionId(nextExecutionId);
+        connectStream(nextExecutionId);
+      } catch (error) {
+        startedAtRef.current = null;
+        setIsRunning(false);
+        setStreamError(extractErrorDetails(error));
+      }
+    },
+    [connectStream, parameters, resetSession]
+  );
+
+  const stopQuery = useCallback(async () => {
+    if (!executionIdRef.current) {
+      return;
+    }
+
+    try {
+      await cancelQueryExecution(executionIdRef.current);
+    } catch (error) {
+      setStreamError(extractErrorDetails(error));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isRunning || startedAtRef.current == null) {
+      return undefined;
+    }
+
+    const tick = () => setElapsedMs(Date.now() - startedAtRef.current);
+    tick();
+    const intervalId = window.setInterval(tick, 1000);
+    return () => window.clearInterval(intervalId);
+  }, [isRunning]);
+
+  useEffect(() => () => closeStream(), [closeStream]);
+
+  const frequencyHistogram = useMemo(
+    () => buildFrequencyHistogram(answers),
+    [answers]
+  );
+
+  const stiChart = useMemo(() => buildStiChart(answers), [answers]);
+
+  return {
+    answers,
+    isRunning,
+    executionId,
+    answerCount,
+    elapsedLabel: formatElapsedLabel(elapsedMs),
+    frequencyHistogram,
+    stiChart,
+    streamError,
+    isCountOnly,
+    startQuery,
+    stopQuery
+  };
+}

--- a/das-dashboard/src/hooks/useQueryExecution.js
+++ b/das-dashboard/src/hooks/useQueryExecution.js
@@ -69,8 +69,8 @@ export function useQueryExecution(parameters) {
       const nextAnswers = chunkItems.map((item, index) => {
         answerSeqRef.current += 1;
         return {
-          id: answerSeqRef.current,
           ...item,
+          id: answerSeqRef.current,
           label: formatQueryAnswer(item, displayOptions),
           importance: Number(item.importance ?? 0),
           strength: Number(item.strength ?? 0),
@@ -180,6 +180,7 @@ export function useQueryExecution(parameters) {
           throw new Error("Query execution did not return an execution id.");
         }
 
+        executionIdRef.current = nextExecutionId;
         setExecutionId(nextExecutionId);
         connectStream(nextExecutionId);
       } catch (error) {
@@ -193,15 +194,18 @@ export function useQueryExecution(parameters) {
 
   const stopQuery = useCallback(async () => {
     if (!executionIdRef.current) {
+      setIsRunning(false);
+      startedAtRef.current = null;
       return;
     }
 
     try {
       await cancelQueryExecution(executionIdRef.current);
+      finishExecution(null);
     } catch (error) {
       setStreamError(extractErrorDetails(error));
     }
-  }, []);
+  }, [finishExecution]);
 
   useEffect(() => {
     if (!isRunning || startedAtRef.current == null) {

--- a/das-dashboard/src/hooks/useQueryExecution.js
+++ b/das-dashboard/src/hooks/useQueryExecution.js
@@ -169,15 +169,9 @@ export function useQueryExecution(parameters) {
       startedAtRef.current = Date.now();
 
       try {
-        const params = {
-          ...parameters.collectParameters(),
-          use_metta_as_query_tokens: true,
-          populate_metta_mapping: true
-        };
-
-        if (parameters.needsParameterApply(params)) {
-          await setQueryParameters(params);
-          parameters.markParametersApplied(params);
+        const pendingParams = parameters.consumeQueryRunParameters();
+        if (Object.keys(pendingParams).length > 0) {
+          await setQueryParameters(pendingParams);
         }
 
         const { execution_id: nextExecutionId } = await startQueryExecution(trimmedQuery);

--- a/das-dashboard/src/hooks/useQueryParameters.jsx
+++ b/das-dashboard/src/hooks/useQueryParameters.jsx
@@ -1,36 +1,156 @@
-import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { getQueryParamDefaults } from "../api/QueryAPI";
 import { buildQueryParameters } from "../utils/queryParameters";
 
 const QueryParametersContext = createContext(null);
 
-function serializeParameters(params) {
-  return JSON.stringify(params);
+const SWITCH_KEYS = [
+  "unique_assignment_flag",
+  "use_link_template_cache",
+  "populate_metta_mapping",
+  "use_metta_as_query_tokens",
+  "allow_incomplete_chain_path",
+  "positive_importance_flag",
+  "disregard_importance_flag",
+  "unique_value_flag",
+  "count_flag"
+];
+
+function switchesFromDefaults(defaults) {
+  return SWITCH_KEYS.reduce((accumulator, key) => {
+    accumulator[key] = Boolean(defaults[key]);
+    return accumulator;
+  }, {});
 }
 
-const INITIAL_SWITCH_STATE = {
-  unique_assignment_flag: false,
-  use_link_template_cache: false,
-  populate_metta_mapping: true,
-  use_metta_as_query_tokens: true,
-  allow_incomplete_chain_path: false,
-  positive_importance_flag: false,
-  disregard_importance_flag: false,
-  unique_value_flag: false,
-  count_flag: false
-};
-
 export function QueryParametersProvider({ children }) {
-  const [attentionUpdate, setAttentionUpdate] = useState(0);
-  const [attentionCorrelation, setAttentionCorrelation] = useState(0);
-  const [attentionFocusStrictness, setAttentionFocusStrictness] = useState(0);
-  const [maxBundleSize, setMaxBundleSize] = useState(1000);
-  const [limitAnswersEnabled, setLimitAnswersEnabled] = useState(false);
-  const [maxAnswersLimit, setMaxAnswersLimit] = useState(1);
-  const [switches, setSwitches] = useState(INITIAL_SWITCH_STATE);
-  const lastAppliedParametersRef = useRef(null);
+  const [attentionUpdate, setAttentionUpdateState] = useState(0);
+  const [attentionCorrelation, setAttentionCorrelationState] = useState(0);
+  const [attentionFocusStrictness, setAttentionFocusStrictnessState] = useState(0);
+  const [maxBundleSize, setMaxBundleSizeState] = useState(1000);
+  const [limitAnswersEnabled, setLimitAnswersEnabledState] = useState(false);
+  const [maxAnswersLimit, setMaxAnswersLimitState] = useState(1);
+  const [switches, setSwitchesState] = useState(() => switchesFromDefaults({}));
+  const queryRunParametersRef = useRef({});
 
-  const collectParameters = () =>
-    buildQueryParameters({
+  const setQueryRunParameter = useCallback((key, value) => {
+    queryRunParametersRef.current = {
+      ...queryRunParametersRef.current,
+      [key]: value
+    };
+  }, []);
+
+  const consumeQueryRunParameters = useCallback(() => {
+    const pending = { ...queryRunParametersRef.current };
+    queryRunParametersRef.current = {};
+    return pending;
+  }, []);
+
+  const applyParameterDefaults = useCallback((defaults) => {
+    if (!defaults || typeof defaults !== "object") {
+      return;
+    }
+
+    setAttentionUpdateState(defaults.attention_update ?? 0);
+    setAttentionCorrelationState(defaults.attention_correlation ?? 0);
+    setAttentionFocusStrictnessState(defaults.attention_focus_strictness ?? 0);
+    setMaxBundleSizeState(defaults.max_bundle_size ?? 1000);
+
+    const maxAnswers = defaults.max_answers ?? 0;
+    setLimitAnswersEnabledState(maxAnswers > 0);
+    setMaxAnswersLimitState(maxAnswers > 0 ? maxAnswers : 1);
+    setSwitchesState(switchesFromDefaults(defaults));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getQueryParamDefaults()
+      .then((defaults) => {
+        if (!cancelled) {
+          applyParameterDefaults(defaults);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applyParameterDefaults]);
+
+  const setAttentionUpdate = useCallback(
+    (value) => {
+      const normalized = Number(value);
+      setAttentionUpdateState(normalized);
+      setQueryRunParameter("attention_update", normalized);
+    },
+    [setQueryRunParameter]
+  );
+
+  const setAttentionCorrelation = useCallback(
+    (value) => {
+      const normalized = Number(value);
+      setAttentionCorrelationState(normalized);
+      setQueryRunParameter("attention_correlation", normalized);
+    },
+    [setQueryRunParameter]
+  );
+
+  const setAttentionFocusStrictness = useCallback(
+    (value) => {
+      setAttentionFocusStrictnessState(value);
+      setQueryRunParameter("attention_focus_strictness", value);
+    },
+    [setQueryRunParameter]
+  );
+
+  const setMaxBundleSize = useCallback(
+    (value) => {
+      const normalized = Number(value);
+      setMaxBundleSizeState(normalized);
+      setQueryRunParameter("max_bundle_size", normalized);
+    },
+    [setQueryRunParameter]
+  );
+
+  const setLimitAnswersEnabled = useCallback(
+    (enabled) => {
+      setLimitAnswersEnabledState(enabled);
+      setQueryRunParameter("max_answers", enabled ? maxAnswersLimit : 0);
+    },
+    [maxAnswersLimit, setQueryRunParameter]
+  );
+
+  const setMaxAnswersLimit = useCallback(
+    (value) => {
+      setMaxAnswersLimitState(value);
+      if (limitAnswersEnabled) {
+        setQueryRunParameter("max_answers", value);
+      }
+    },
+    [limitAnswersEnabled, setQueryRunParameter]
+  );
+
+  const updateSwitch = useCallback(
+    (key, checked) => {
+      setSwitchesState((previous) => ({ ...previous, [key]: checked }));
+      setQueryRunParameter(key, checked);
+    },
+    [setQueryRunParameter]
+  );
+
+  const collectParameters = useCallback(
+    () =>
+      buildQueryParameters({
+        attentionUpdate,
+        attentionCorrelation,
+        attentionFocusStrictness,
+        maxBundleSize,
+        limitAnswersEnabled,
+        maxAnswersLimit,
+        switches
+      }),
+    [
       attentionUpdate,
       attentionCorrelation,
       attentionFocusStrictness,
@@ -38,19 +158,8 @@ export function QueryParametersProvider({ children }) {
       limitAnswersEnabled,
       maxAnswersLimit,
       switches
-    });
-
-  const needsParameterApply = useCallback((params) => {
-    return serializeParameters(params) !== lastAppliedParametersRef.current;
-  }, []);
-
-  const markParametersApplied = useCallback((params) => {
-    lastAppliedParametersRef.current = serializeParameters(params);
-  }, []);
-
-  const updateSwitch = (key, checked) => {
-    setSwitches((previous) => ({ ...previous, [key]: checked }));
-  };
+    ]
+  );
 
   const value = {
     attentionUpdate,
@@ -67,9 +176,8 @@ export function QueryParametersProvider({ children }) {
     setMaxAnswersLimit,
     switches,
     updateSwitch,
+    consumeQueryRunParameters,
     collectParameters,
-    needsParameterApply,
-    markParametersApplied,
     isCountOnly: switches.count_flag
   };
 

--- a/das-dashboard/src/hooks/useQueryParameters.jsx
+++ b/das-dashboard/src/hooks/useQueryParameters.jsx
@@ -51,6 +51,7 @@ export function QueryParametersProvider({ children }) {
       return;
     }
 
+    queryRunParametersRef.current = {};
     setAttentionUpdateState(defaults.attention_update ?? 0);
     setAttentionCorrelationState(defaults.attention_correlation ?? 0);
     setAttentionFocusStrictnessState(defaults.attention_focus_strictness ?? 0);

--- a/das-dashboard/src/hooks/useQueryParameters.jsx
+++ b/das-dashboard/src/hooks/useQueryParameters.jsx
@@ -1,0 +1,89 @@
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { buildQueryParameters } from "../utils/queryParameters";
+
+const QueryParametersContext = createContext(null);
+
+function serializeParameters(params) {
+  return JSON.stringify(params);
+}
+
+const INITIAL_SWITCH_STATE = {
+  unique_assignment_flag: false,
+  use_link_template_cache: false,
+  populate_metta_mapping: true,
+  use_metta_as_query_tokens: true,
+  allow_incomplete_chain_path: false,
+  positive_importance_flag: false,
+  disregard_importance_flag: false,
+  unique_value_flag: false,
+  count_flag: false
+};
+
+export function QueryParametersProvider({ children }) {
+  const [attentionUpdate, setAttentionUpdate] = useState(0);
+  const [attentionCorrelation, setAttentionCorrelation] = useState(0);
+  const [attentionFocusStrictness, setAttentionFocusStrictness] = useState(0);
+  const [maxBundleSize, setMaxBundleSize] = useState(1000);
+  const [limitAnswersEnabled, setLimitAnswersEnabled] = useState(false);
+  const [maxAnswersLimit, setMaxAnswersLimit] = useState(1);
+  const [switches, setSwitches] = useState(INITIAL_SWITCH_STATE);
+  const lastAppliedParametersRef = useRef(null);
+
+  const collectParameters = () =>
+    buildQueryParameters({
+      attentionUpdate,
+      attentionCorrelation,
+      attentionFocusStrictness,
+      maxBundleSize,
+      limitAnswersEnabled,
+      maxAnswersLimit,
+      switches
+    });
+
+  const needsParameterApply = useCallback((params) => {
+    return serializeParameters(params) !== lastAppliedParametersRef.current;
+  }, []);
+
+  const markParametersApplied = useCallback((params) => {
+    lastAppliedParametersRef.current = serializeParameters(params);
+  }, []);
+
+  const updateSwitch = (key, checked) => {
+    setSwitches((previous) => ({ ...previous, [key]: checked }));
+  };
+
+  const value = {
+    attentionUpdate,
+    setAttentionUpdate,
+    attentionCorrelation,
+    setAttentionCorrelation,
+    attentionFocusStrictness,
+    setAttentionFocusStrictness,
+    maxBundleSize,
+    setMaxBundleSize,
+    limitAnswersEnabled,
+    setLimitAnswersEnabled,
+    maxAnswersLimit,
+    setMaxAnswersLimit,
+    switches,
+    updateSwitch,
+    collectParameters,
+    needsParameterApply,
+    markParametersApplied,
+    isCountOnly: switches.count_flag
+  };
+
+  return (
+    <QueryParametersContext.Provider value={value}>
+      {children}
+    </QueryParametersContext.Provider>
+  );
+}
+
+export function useQueryParameters() {
+  const context = useContext(QueryParametersContext);
+  if (!context) {
+    throw new Error("useQueryParameters must be used inside QueryParametersProvider");
+  }
+  return context;
+}

--- a/das-dashboard/src/pages/dashboard/Dashboard.jsx
+++ b/das-dashboard/src/pages/dashboard/Dashboard.jsx
@@ -2,6 +2,7 @@ import ArchitectureView from "../../components/dashboard/ArchitectureView/Archit
 import { MainContent } from "../../components/dashboard/MainContent/MainContent";
 import { ServerTab } from "../../components/dashboard/MainContent/servertab/ServerTab";
 import { SideBar } from "../../components/dashboard/MainContent/sidebar/SideBar";
+import DashboardContextProvider from "../../components/global_providers/DashboardContextProvider";
 import { ServerTabMetricsProvider } from "../../components/global_providers/ServerTabMetricsProvider";
 import { ArchitectureTabMetricsProvider } from "../../components/global_providers/ArchitectureTabMetricsProvider";
 import { useDashboardContext } from "../../components/global_providers/DashboardContextProvider";
@@ -82,10 +83,12 @@ function DashboardPageContent() {
 
 export default function DashboardPage() {
   return (
-    <ServerTabMetricsProvider>
-      <ArchitectureTabMetricsProvider>
-        <DashboardPageContent />
-      </ArchitectureTabMetricsProvider>
-    </ServerTabMetricsProvider>
+    <DashboardContextProvider>
+      <ServerTabMetricsProvider>
+        <ArchitectureTabMetricsProvider>
+          <DashboardPageContent />
+        </ArchitectureTabMetricsProvider>
+      </ServerTabMetricsProvider>
+    </DashboardContextProvider>
   );
 }

--- a/das-dashboard/src/pages/query/QueryPage.jsx
+++ b/das-dashboard/src/pages/query/QueryPage.jsx
@@ -7,6 +7,10 @@ import QueryFrequencyHistogram from "../../components/query_page/QueryFrequencyH
 import QueryImportanceChart from "../../components/query_page/QueryImportanceChart";
 import QueryStatusBar from "../../components/query_page/QueryStatusBar";
 import {
+  QueryExecutionProvider,
+  useQueryExecutionContext
+} from "../../components/global_providers/QueryExecutionProvider";
+import {
   PageContainer,
   ParamSideBar,
   QueryBreadcrumb,
@@ -27,20 +31,31 @@ import {
   SideBarSubtitle,
   SideBarTitle,
   SideBarTitleHeader,
-  StopButton
+  StopButton,
+  QueryStreamError
 } from "./querypage.styled";
 
-const EMPTY_HISTOGRAM = {
-  counts: Array(30).fill(0),
-  labels: Array.from({ length: 30 }, (_, index) => String(index + 1)),
-  scaleLabel: "1 minute",
-  maxCount: 1
-};
-
-export default function QueryPage() {
+function QueryPageContent() {
   const [queryText, setQueryText] = useState(
-    '(Evaluation (Predicate (public.cvterm "FBgn0034331")) (Concept "gene"))'
+    ''
   );
+
+  const {
+    answers,
+    isRunning,
+    executionId,
+    answerCount,
+    elapsedLabel,
+    frequencyHistogram,
+    stiChart,
+    streamError,
+    isCountOnly,
+    startQuery,
+    stopQuery
+  } = useQueryExecutionContext();
+
+  const canRun = queryText.trim().length > 0 && !isRunning;
+  const canStop = isRunning && executionId != null;
 
   return (
     <PageContainer>
@@ -76,7 +91,8 @@ export default function QueryPage() {
                   variant="contained"
                   disableElevation
                   startIcon={<PlayArrowIcon />}
-                  disabled={!queryText.trim()}
+                  disabled={!canRun}
+                  onClick={() => startQuery(queryText)}
                 >
                   Run
                 </RunButton>
@@ -84,7 +100,8 @@ export default function QueryPage() {
                   variant="contained"
                   disableElevation
                   startIcon={<StopIcon />}
-                  disabled
+                  disabled={!canStop}
+                  onClick={stopQuery}
                 >
                   Stop
                 </StopButton>
@@ -103,21 +120,40 @@ export default function QueryPage() {
           </QueryCard>
 
           <QueryStatusBar
-            status="idle"
-            answerCount={0}
-            elapsedLabel="00:00"
-            answersPerSecond={0}
+            isRunning={isRunning}
+            answerCount={answerCount}
+            elapsedLabel={elapsedLabel}
+            executionId={executionId}
+            isCountOnly={isCountOnly}
           />
 
+          {streamError ? (
+            <QueryStreamError>{streamError}</QueryStreamError>
+          ) : null}
+
           <ResultsSection>
-            <QueryAnswersPanel answers={[]} isRunning={false} />
+            <QueryAnswersPanel
+              answers={answers}
+              executionId={executionId}
+              isRunning={isRunning}
+              isCountOnly={isCountOnly}
+              totalAnswers={answerCount}
+            />
             <ChartsRow>
-              <QueryFrequencyHistogram histogram={EMPTY_HISTOGRAM} />
-              <QueryImportanceChart />
+              <QueryFrequencyHistogram histogram={frequencyHistogram} />
+              <QueryImportanceChart chart={stiChart} />
             </ChartsRow>
           </ResultsSection>
         </QueryContentBody>
       </QueryContent>
     </PageContainer>
+  );
+}
+
+export default function QueryPage() {
+  return (
+    <QueryExecutionProvider>
+      <QueryPageContent />
+    </QueryExecutionProvider>
   );
 }

--- a/das-dashboard/src/pages/query/QueryPage.jsx
+++ b/das-dashboard/src/pages/query/QueryPage.jsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import StopIcon from "@mui/icons-material/Stop";
+import ParameterSection from "../../components/query_page/ParameterSection";
+import QueryAnswersPanel from "../../components/query_page/QueryAnswersPanel";
+import QueryFrequencyHistogram from "../../components/query_page/QueryFrequencyHistogram";
+import QueryImportanceChart from "../../components/query_page/QueryImportanceChart";
+import QueryStatusBar from "../../components/query_page/QueryStatusBar";
+import {
+  PageContainer,
+  ParamSideBar,
+  QueryBreadcrumb,
+  QueryCard,
+  QueryContent,
+  QueryContentBody,
+  QueryContentHeader,
+  QueryInput,
+  QueryKindChip,
+  QueryPageSubtitle,
+  QueryPageTitle,
+  QueryToolbar,
+  QueryToolbarActions,
+  ChartsRow,
+  ResultsSection,
+  RunButton,
+  SideBarEyebrow,
+  SideBarSubtitle,
+  SideBarTitle,
+  SideBarTitleHeader,
+  StopButton
+} from "./querypage.styled";
+
+const EMPTY_HISTOGRAM = {
+  counts: Array(30).fill(0),
+  labels: Array.from({ length: 30 }, (_, index) => String(index + 1)),
+  scaleLabel: "1 minute",
+  maxCount: 1
+};
+
+export default function QueryPage() {
+  const [queryText, setQueryText] = useState(
+    '(Evaluation (Predicate (public.cvterm "FBgn0034331")) (Concept "gene"))'
+  );
+
+  return (
+    <PageContainer>
+      <ParamSideBar>
+        <SideBarTitleHeader>
+          <SideBarEyebrow>Parameters</SideBarEyebrow>
+          <SideBarTitle>Query inputs</SideBarTitle>
+          <SideBarSubtitle>
+            Configure the parameters for your MeTTa query.
+          </SideBarSubtitle>
+        </SideBarTitleHeader>
+
+        <ParameterSection />
+      </ParamSideBar>
+
+      <QueryContent>
+        <QueryContentHeader>
+          <QueryBreadcrumb>
+            Query <span>{'>'}</span> Workspace
+          </QueryBreadcrumb>
+          <QueryPageTitle>MeTTa query</QueryPageTitle>
+          <QueryPageSubtitle>
+            Compose and run a MeTTa query against the distributed AtomSpace.
+          </QueryPageSubtitle>
+        </QueryContentHeader>
+
+        <QueryContentBody>
+          <QueryCard>
+            <QueryToolbar>
+              <QueryKindChip>Query</QueryKindChip>
+              <QueryToolbarActions>
+                <RunButton
+                  variant="contained"
+                  disableElevation
+                  startIcon={<PlayArrowIcon />}
+                  disabled={!queryText.trim()}
+                >
+                  Run
+                </RunButton>
+                <StopButton
+                  variant="contained"
+                  disableElevation
+                  startIcon={<StopIcon />}
+                  disabled
+                >
+                  Stop
+                </StopButton>
+              </QueryToolbarActions>
+            </QueryToolbar>
+
+            <QueryInput
+              multiline
+              minRows={5}
+              maxRows={12}
+              fullWidth
+              value={queryText}
+              onChange={(event) => setQueryText(event.target.value)}
+              placeholder="Enter a MeTTa expression…"
+            />
+          </QueryCard>
+
+          <QueryStatusBar
+            status="idle"
+            answerCount={0}
+            elapsedLabel="00:00"
+            answersPerSecond={0}
+          />
+
+          <ResultsSection>
+            <QueryAnswersPanel answers={[]} isRunning={false} />
+            <ChartsRow>
+              <QueryFrequencyHistogram histogram={EMPTY_HISTOGRAM} />
+              <QueryImportanceChart />
+            </ChartsRow>
+          </ResultsSection>
+        </QueryContentBody>
+      </QueryContent>
+    </PageContainer>
+  );
+}

--- a/das-dashboard/src/pages/query/QueryPage.jsx
+++ b/das-dashboard/src/pages/query/QueryPage.jsx
@@ -71,7 +71,7 @@ function QueryPageContent() {
           <SideBarEyebrow>Parameters</SideBarEyebrow>
           <SideBarTitle>Query inputs</SideBarTitle>
           <SideBarSubtitle>
-            Configure the parameters for your MeTTa query.
+            Configure the parameters for your query.
           </SideBarSubtitle>
         </SideBarTitleHeader>
 
@@ -80,12 +80,9 @@ function QueryPageContent() {
 
       <QueryContent>
         <QueryContentHeader>
-          <QueryBreadcrumb>
-            Query <span>{'>'}</span> Workspace
-          </QueryBreadcrumb>
-          <QueryPageTitle>MeTTa query</QueryPageTitle>
+          <QueryPageTitle>Query</QueryPageTitle>
           <QueryPageSubtitle>
-            Compose and run a MeTTa query against the distributed AtomSpace.
+            Compose and run a query on the Distributed AtomSpace.
           </QueryPageSubtitle>
         </QueryContentHeader>
 
@@ -95,7 +92,7 @@ function QueryPageContent() {
               <QueryToolbarLeading>
                 <QueryKindChip>Query</QueryKindChip>
                 <QueryMettaSwitch
-                  label="Use metta query"
+                  label="Use MeTTa query"
                   labelPlacement="end"
                   control={
                     <Switch
@@ -145,7 +142,7 @@ function QueryPageContent() {
               fullWidth
               value={queryText}
               onChange={(event) => setQueryText(event.target.value)}
-              placeholder="Enter a MeTTa expression…"
+              placeholder="Enter a query expression…"
             />
           </QueryCard>
 

--- a/das-dashboard/src/pages/query/QueryPage.jsx
+++ b/das-dashboard/src/pages/query/QueryPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
+import { Switch } from "@mui/material";
 import ParameterSection from "../../components/query_page/ParameterSection";
 import QueryAnswersPanel from "../../components/query_page/QueryAnswersPanel";
 import QueryFrequencyHistogram from "../../components/query_page/QueryFrequencyHistogram";
@@ -10,6 +11,7 @@ import {
   QueryExecutionProvider,
   useQueryExecutionContext
 } from "../../components/global_providers/QueryExecutionProvider";
+import { useQueryParameters } from "../../hooks/useQueryParameters";
 import {
   PageContainer,
   ParamSideBar,
@@ -20,10 +22,13 @@ import {
   QueryContentHeader,
   QueryInput,
   QueryKindChip,
+  QueryMettaSwitch,
   QueryPageSubtitle,
   QueryPageTitle,
   QueryToolbar,
   QueryToolbarActions,
+  QueryToolbarLeading,
+  paletteQuery,
   ChartsRow,
   ResultsSection,
   RunButton,
@@ -53,6 +58,8 @@ function QueryPageContent() {
     startQuery,
     stopQuery
   } = useQueryExecutionContext();
+
+  const { switches, updateSwitch } = useQueryParameters();
 
   const canRun = queryText.trim().length > 0 && !isRunning;
   const canStop = isRunning && executionId != null;
@@ -85,7 +92,30 @@ function QueryPageContent() {
         <QueryContentBody>
           <QueryCard>
             <QueryToolbar>
-              <QueryKindChip>Query</QueryKindChip>
+              <QueryToolbarLeading>
+                <QueryKindChip>Query</QueryKindChip>
+                <QueryMettaSwitch
+                  label="Use metta query"
+                  labelPlacement="end"
+                  control={
+                    <Switch
+                      size="small"
+                      checked={switches.use_metta_as_query_tokens}
+                      onChange={(event) =>
+                        updateSwitch("use_metta_as_query_tokens", event.target.checked)
+                      }
+                      sx={{
+                        "& .MuiSwitch-switchBase.Mui-checked": {
+                          color: paletteQuery.accent
+                        },
+                        "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                          backgroundColor: paletteQuery.accent
+                        }
+                      }}
+                    />
+                  }
+                />
+              </QueryToolbarLeading>
               <QueryToolbarActions>
                 <RunButton
                   variant="contained"

--- a/das-dashboard/src/pages/query/querypage.styled.js
+++ b/das-dashboard/src/pages/query/querypage.styled.js
@@ -132,6 +132,16 @@ export const ParameterApplyMessage = styled(Typography)({
   }
 });
 
+export const QueryStreamError = styled(Typography)({
+  fontSize: 13,
+  lineHeight: 1.45,
+  color: paletteQuery.danger,
+  padding: "10px 14px",
+  borderRadius: 8,
+  border: `1px solid rgba(220, 38, 38, 0.25)`,
+  backgroundColor: "rgba(220, 38, 38, 0.06)"
+});
+
 export const ParameterDivider = styled(Box)({
   height: 1,
   backgroundColor: paletteQuery.borderSubtle,
@@ -343,6 +353,11 @@ export const StatusPill = styled(Box, {
   shouldForwardProp: (prop) => prop !== "tone"
 })(({ tone }) => {
   const tones = {
+    rest: {
+      backgroundColor: paletteQuery.surfaceMuted,
+      color: paletteQuery.textSecondary,
+      borderColor: paletteQuery.border
+    },
     idle: {
       backgroundColor: paletteQuery.surfaceMuted,
       color: paletteQuery.textSecondary,
@@ -365,7 +380,7 @@ export const StatusPill = styled(Box, {
     }
   };
 
-  const style = tones[tone] || tones.idle;
+  const style = tones[tone] || tones.rest;
 
   return {
     display: "inline-flex",
@@ -584,4 +599,19 @@ export const StreamingHint = styled(Typography)({
   fontSize: 12,
   fontStyle: "italic",
   color: paletteQuery.textMuted
+});
+
+export const AllAnswersModalPaper = {
+  borderRadius: "2px",
+  backgroundColor: paletteQuery.surface,
+  boxShadow: paletteQuery.shadow,
+  border: `1px solid ${paletteQuery.borderSubtle}`
+};
+
+export const AllAnswersList = styled(Box)({
+  maxHeight: 420,
+  overflowY: "auto",
+  border: `1px solid ${paletteQuery.borderSubtle}`,
+  borderRadius: "2px",
+  backgroundColor: paletteQuery.surface
 });

--- a/das-dashboard/src/pages/query/querypage.styled.js
+++ b/das-dashboard/src/pages/query/querypage.styled.js
@@ -75,6 +75,13 @@ export const SideBarSubtitle = styled(Typography)({
   lineHeight: 1.45
 });
 
+export const ParameterSectionRoot = styled(Box)({
+  flex: 1,
+  minHeight: 0,
+  display: "flex",
+  flexDirection: "column"
+});
+
 export const ParameterSectionBody = styled(Box)({
   flex: 1,
   minHeight: 0,
@@ -84,6 +91,45 @@ export const ParameterSectionBody = styled(Box)({
   flexDirection: "column",
   gap: 16,
   boxSizing: "border-box"
+});
+
+export const ParameterApplyFooter = styled(Box)({
+  flexShrink: 0,
+  padding: "12px 18px 16px",
+  borderTop: `1px solid ${paletteQuery.borderSubtle}`,
+  backgroundColor: paletteQuery.surface,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8
+});
+
+export const ApplyParametersButton = styled(Button)({
+  textTransform: "none",
+  fontWeight: 600,
+  borderRadius: 8,
+  height: 36,
+  boxShadow: "none",
+  backgroundColor: paletteQuery.accent,
+  "&:hover": {
+    backgroundColor: paletteQuery.accentHover,
+    boxShadow: "none"
+  },
+  "&.Mui-disabled": {
+    backgroundColor: paletteQuery.borderSubtle,
+    color: paletteQuery.textMuted
+  }
+});
+
+export const ParameterApplyMessage = styled(Typography)({
+  fontSize: 12,
+  lineHeight: 1.4,
+  color: paletteQuery.textSecondary,
+  "&.error": {
+    color: paletteQuery.danger
+  },
+  "&.success": {
+    color: paletteQuery.successHover
+  }
 });
 
 export const ParameterDivider = styled(Box)({

--- a/das-dashboard/src/pages/query/querypage.styled.js
+++ b/das-dashboard/src/pages/query/querypage.styled.js
@@ -1,0 +1,541 @@
+import { Box, Button, TextField, Typography, styled, keyframes } from "@mui/material";
+
+export const paletteQuery = {
+  background: "#f4f4f6",
+  surface: "#ffffff",
+  surfaceMuted: "#f9fafb",
+  sidebar: "#ffffff",
+  border: "#e5e7eb",
+  borderSubtle: "#f0f1f3",
+  textPrimary: "#111827",
+  textSecondary: "#6b7280",
+  textMuted: "#9ca3af",
+  accent: "#4f46e5",
+  accentHover: "#4338ca",
+  accentLight: "#eef2ff",
+  accentMuted: "#e0e7ff",
+  success: "#33e622",
+  successHover: "#24ac18",
+  danger: "#dc2626",
+  dangerHover: "#b91c1c",
+  shadow: "0 1px 3px rgba(15, 23, 42, 0.06), 0 4px 16px rgba(15, 23, 42, 0.04)"
+};
+
+export const PageContainer = styled(Box)({
+  display: "flex",
+  flexDirection: "row",
+  width: "100%",
+  height: "100%",
+  maxWidth: "100%",
+  overflow: "hidden",
+  boxSizing: "border-box",
+  backgroundColor: paletteQuery.background
+});
+
+export const ParamSideBar = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  width: 320,
+  minWidth: 320,
+  flexShrink: 0,
+  height: "100%",
+  backgroundColor: paletteQuery.sidebar,
+  borderRight: `1px solid ${paletteQuery.border}`,
+  boxSizing: "border-box",
+  overflow: "hidden"
+});
+
+export const SideBarTitleHeader = styled(Box)({
+  flexShrink: 0,
+  padding: "18px 20px 16px",
+  borderBottom: `1px solid ${paletteQuery.borderSubtle}`,
+  background: `linear-gradient(180deg, ${paletteQuery.accentLight} 0%, ${paletteQuery.surface} 100%)`
+});
+
+export const SideBarEyebrow = styled(Typography)({
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: paletteQuery.accent,
+  marginBottom: 4
+});
+
+export const SideBarTitle = styled(Typography)({
+  fontSize: 16,
+  fontWeight: 600,
+  color: paletteQuery.textPrimary,
+  letterSpacing: "-0.02em"
+});
+
+export const SideBarSubtitle = styled(Typography)({
+  fontSize: 12,
+  color: paletteQuery.textSecondary,
+  marginTop: 4,
+  lineHeight: 1.45
+});
+
+export const ParameterSectionBody = styled(Box)({
+  flex: 1,
+  minHeight: 0,
+  overflowY: "auto",
+  padding: "16px 18px 20px",
+  display: "flex",
+  flexDirection: "column",
+  gap: 16,
+  boxSizing: "border-box"
+});
+
+export const ParameterDivider = styled(Box)({
+  height: 1,
+  backgroundColor: paletteQuery.borderSubtle,
+  margin: "4px 0"
+});
+
+export const ParameterFieldGrid = styled(Box)({
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: 12
+});
+
+export const ParameterSwitchStack = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: 2
+});
+
+export const SliderRow = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: 6
+});
+
+export const SliderLabelRow = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 8
+});
+
+export const SliderLabel = styled(Typography)({
+  fontSize: 13,
+  fontWeight: 500,
+  color: paletteQuery.textPrimary
+});
+
+export const SliderValue = styled(Typography)({
+  fontSize: 12,
+  fontWeight: 600,
+  color: paletteQuery.textSecondary,
+  fontVariantNumeric: "tabular-nums"
+});
+
+export const QueryContent = styled(Box)({
+  flex: 1,
+  minWidth: 0,
+  minHeight: 0,
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+  backgroundColor: paletteQuery.background
+});
+
+export const QueryContentHeader = styled(Box)({
+  flexShrink: 0,
+  padding: "14px 28px 12px",
+  borderBottom: `1px solid ${paletteQuery.borderSubtle}`,
+  backgroundColor: paletteQuery.surface,
+  boxSizing: "border-box"
+});
+
+export const QueryBreadcrumb = styled(Typography)({
+  fontSize: 12,
+  color: paletteQuery.textMuted,
+  fontWeight: 500,
+  "& span": {
+    color: paletteQuery.textSecondary
+  }
+});
+
+export const QueryPageTitle = styled(Typography)({
+  fontSize: 18,
+  fontWeight: 600,
+  color: paletteQuery.textPrimary,
+  letterSpacing: "-0.02em",
+  marginTop: 2
+});
+
+export const QueryPageSubtitle = styled(Typography)({
+  fontSize: 13,
+  color: paletteQuery.textSecondary,
+  marginTop: 2
+});
+
+export const QueryContentBody = styled(Box)({
+  flex: 1,
+  minHeight: 0,
+  overflowY: "auto",
+  padding: "20px 28px 28px",
+  display: "flex",
+  flexDirection: "column",
+  gap: 14,
+  boxSizing: "border-box"
+});
+
+export const QueryCard = styled(Box)({
+  backgroundColor: paletteQuery.surface,
+  border: `1px solid ${paletteQuery.borderSubtle}`,
+  borderRadius: 12,
+  boxShadow: paletteQuery.shadow,
+  padding: "14px 16px 16px",
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  boxSizing: "border-box"
+});
+
+export const QueryToolbar = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 12
+});
+
+export const QueryKindChip = styled(Box)({
+  display: "inline-flex",
+  alignItems: "center",
+  height: 28,
+  padding: "0 12px",
+  borderRadius: 8,
+  border: `1px solid ${paletteQuery.accentMuted}`,
+  backgroundColor: paletteQuery.accentLight,
+  color: paletteQuery.accent,
+  fontSize: 13,
+  fontWeight: 600
+});
+
+export const QueryToolbarActions = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  gap: 8
+});
+
+export const RunButton = styled(Button)({
+  textTransform: "none",
+  fontWeight: 600,
+  borderRadius: 8,
+  minWidth: 80,
+  height: 34,
+  boxShadow: "none",
+  backgroundColor: paletteQuery.accent,
+  "&:hover": {
+    backgroundColor: paletteQuery.accentHover,
+    boxShadow: "none"
+  }
+});
+
+export const StopButton = styled(Button)({
+  textTransform: "none",
+  fontWeight: 600,
+  borderRadius: 8,
+  minWidth: 80,
+  height: 34,
+  boxShadow: "none",
+  color: paletteQuery.textSecondary,
+  backgroundColor: paletteQuery.surface,
+  border: `1px solid ${paletteQuery.border}`,
+  "&:hover": {
+    backgroundColor: paletteQuery.surfaceMuted,
+    boxShadow: "none"
+  }
+});
+
+export const QueryInput = styled(TextField)({
+  "& .MuiOutlinedInput-root": {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+    fontSize: 13,
+    lineHeight: 1.5,
+    backgroundColor: paletteQuery.surfaceMuted,
+    borderRadius: 10,
+    alignItems: "flex-start",
+    "& fieldset": {
+      borderColor: paletteQuery.border
+    },
+    "&:hover fieldset": {
+      borderColor: paletteQuery.accentMuted
+    },
+    "&.Mui-focused fieldset": {
+      borderColor: paletteQuery.accent,
+      borderWidth: 1
+    }
+  },
+  "& .MuiOutlinedInput-input": {
+    padding: "12px 14px"
+  }
+});
+
+export const GeneralStatusBar = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: 12,
+  padding: "12px 16px",
+  borderRadius: 12,
+  border: `1px solid ${paletteQuery.borderSubtle}`,
+  background: `linear-gradient(180deg, ${paletteQuery.surface} 0%, ${paletteQuery.surfaceMuted} 100%)`,
+  boxShadow: paletteQuery.shadow,
+  boxSizing: "border-box"
+});
+
+const statusPulse = keyframes`
+  0% { box-shadow: 0 0 0 0 rgba(79, 70, 229, 0.35); }
+  70% { box-shadow: 0 0 0 6px rgba(79, 70, 229, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(79, 70, 229, 0); }
+`;
+
+export const StatusPill = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "tone"
+})(({ tone }) => {
+  const tones = {
+    idle: {
+      backgroundColor: paletteQuery.surfaceMuted,
+      color: paletteQuery.textSecondary,
+      borderColor: paletteQuery.border
+    },
+    running: {
+      backgroundColor: paletteQuery.accentLight,
+      color: paletteQuery.accent,
+      borderColor: paletteQuery.accentMuted
+    },
+    done: {
+      backgroundColor: "rgba(51, 230, 34, 0.12)",
+      color: paletteQuery.successHover,
+      borderColor: "rgba(51, 230, 34, 0.35)"
+    },
+    stopped: {
+      backgroundColor: "rgba(220, 38, 38, 0.08)",
+      color: paletteQuery.danger,
+      borderColor: "rgba(220, 38, 38, 0.25)"
+    }
+  };
+
+  const style = tones[tone] || tones.idle;
+
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    height: 28,
+    padding: "0 12px",
+    borderRadius: 999,
+    border: `1px solid ${style.borderColor}`,
+    backgroundColor: style.backgroundColor,
+    color: style.color,
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: "0.02em",
+    animation: tone === "running" ? `${statusPulse} 1.8s ease-out infinite` : "none"
+  };
+});
+
+export const StatusDot = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "tone"
+})(({ tone }) => ({
+  width: 7,
+  height: 7,
+  borderRadius: "50%",
+  backgroundColor:
+    tone === "running"
+      ? paletteQuery.accent
+      : tone === "done"
+        ? paletteQuery.successHover
+        : tone === "stopped"
+          ? paletteQuery.danger
+          : paletteQuery.textMuted
+}));
+
+export const StatusMetrics = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: 0,
+  minWidth: 0
+});
+
+export const StatusMetric = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: 1,
+  padding: "0 14px",
+  minWidth: 88
+});
+
+export const StatusMetricLabel = styled(Typography)({
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+  color: paletteQuery.textMuted
+});
+
+export const StatusMetricValue = styled(Typography)({
+  fontSize: 14,
+  fontWeight: 600,
+  color: paletteQuery.textPrimary,
+  fontVariantNumeric: "tabular-nums"
+});
+
+export const StatusDivider = styled(Box)({
+  width: 1,
+  alignSelf: "stretch",
+  minHeight: 34,
+  backgroundColor: paletteQuery.borderSubtle
+});
+
+export const ResultsSection = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: 14,
+  minHeight: 0
+});
+
+export const ChartsRow = styled(Box)({
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+  gap: 14,
+  minHeight: 320,
+  "@media (max-width: 1100px)": {
+    gridTemplateColumns: "1fr"
+  }
+});
+
+export const ParameterLimitField = styled(Box)({
+  display: "flex",
+  flexDirection: "column",
+  gap: 8
+});
+
+export const QueryResultsCard = styled(Box)({
+  backgroundColor: paletteQuery.surface,
+  border: `1px solid ${paletteQuery.borderSubtle}`,
+  borderRadius: 12,
+  boxShadow: paletteQuery.shadow,
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 220,
+  maxHeight: 360,
+  overflow: "hidden",
+  boxSizing: "border-box"
+});
+
+export const AnswerHistogramCard = styled(Box)({
+  backgroundColor: paletteQuery.surface,
+  border: `1px solid ${paletteQuery.borderSubtle}`,
+  borderRadius: 12,
+  boxShadow: paletteQuery.shadow,
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 300,
+  overflow: "hidden",
+  boxSizing: "border-box"
+});
+
+export const PanelHeader = styled(Box)({
+  flexShrink: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 12,
+  padding: "12px 16px",
+  borderBottom: `1px solid ${paletteQuery.borderSubtle}`
+});
+
+export const PanelTitle = styled(Typography)({
+  fontSize: 14,
+  fontWeight: 600,
+  color: paletteQuery.textPrimary
+});
+
+export const PanelMeta = styled(Typography)({
+  fontSize: 12,
+  fontWeight: 500,
+  color: paletteQuery.textMuted
+});
+
+export const ResultsList = styled(Box)({
+  flex: 1,
+  minHeight: 0,
+  overflowY: "auto",
+  padding: "4px 0"
+});
+
+export const ResultRow = styled(Box)({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 10,
+  padding: "10px 16px",
+  borderBottom: `1px solid ${paletteQuery.borderSubtle}`,
+  "&:last-child": {
+    borderBottom: "none"
+  }
+});
+
+export const ResultAccent = styled(Box)({
+  width: 3,
+  minHeight: 16,
+  marginTop: 3,
+  borderRadius: 2,
+  backgroundColor: paletteQuery.accent,
+  flexShrink: 0
+});
+
+export const ResultText = styled(Typography)({
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+  fontSize: 12.5,
+  lineHeight: 1.45,
+  color: paletteQuery.textPrimary,
+  wordBreak: "break-word"
+});
+
+export const ResultsFooter = styled(Box)({
+  flexShrink: 0,
+  padding: "10px 16px 14px",
+  borderTop: `1px solid ${paletteQuery.borderSubtle}`
+});
+
+export const ResultsFooterLink = styled(Typography)({
+  fontSize: 13,
+  fontWeight: 500,
+  color: paletteQuery.accent,
+  cursor: "pointer",
+  "&:hover": {
+    color: paletteQuery.accentHover
+  }
+});
+
+export const HistogramBody = styled(Box)({
+  flex: 1,
+  minHeight: 0,
+  padding: "4px 8px 8px",
+  boxSizing: "border-box"
+});
+
+export const EmptyPanelState = styled(Box)({
+  flex: 1,
+  minHeight: 180,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 24,
+  color: paletteQuery.textMuted,
+  fontSize: 13,
+  textAlign: "center",
+  lineHeight: 1.5
+});
+
+export const StreamingHint = styled(Typography)({
+  padding: "10px 16px 14px",
+  fontSize: 12,
+  fontStyle: "italic",
+  color: paletteQuery.textMuted
+});

--- a/das-dashboard/src/pages/query/querypage.styled.js
+++ b/das-dashboard/src/pages/query/querypage.styled.js
@@ -1,4 +1,4 @@
-import { Box, Button, TextField, Typography, styled, keyframes } from "@mui/material";
+import { Box, Button, FormControlLabel, TextField, Typography, styled, keyframes } from "@mui/material";
 
 export const paletteQuery = {
   background: "#f4f4f6",
@@ -255,6 +255,23 @@ export const QueryToolbar = styled(Box)({
   alignItems: "center",
   justifyContent: "space-between",
   gap: 12
+});
+
+export const QueryToolbarLeading = styled(Box)({
+  display: "flex",
+  alignItems: "center",
+  gap: 16,
+  minWidth: 0
+});
+
+export const QueryMettaSwitch = styled(FormControlLabel)({
+  margin: 0,
+  gap: 8,
+  "& .MuiFormControlLabel-label": {
+    fontSize: 13,
+    color: paletteQuery.textPrimary,
+    whiteSpace: "nowrap"
+  }
 });
 
 export const QueryKindChip = styled(Box)({

--- a/das-dashboard/src/utils/formatQueryAnswer.js
+++ b/das-dashboard/src/utils/formatQueryAnswer.js
@@ -1,15 +1,40 @@
-export function formatQueryAnswer(answer) {
+function flattenNestedValues(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return [];
+  }
+
+  return values.flatMap((entry) =>
+    Array.isArray(entry) ? entry.map(String) : [String(entry)]
+  );
+}
+
+function formatHandles(handles) {
+  const flattened = flattenNestedValues(handles);
+  return flattened.length > 0 ? flattened.join(" | ") : "(no handles)";
+}
+
+function formatMettaContent(answer) {
+  const expressionLines = flattenNestedValues(answer.metta_expressions ?? answer.metta);
+  const assignmentMetta = answer.assignment_metta ?? {};
+  const assignmentLines = Object.entries(assignmentMetta).map(
+    ([key, value]) => `${key}: ${value}`
+  );
+
+  const parts = [...expressionLines, ...assignmentLines];
+  return parts.length > 0 ? parts.join("\n") : "(no metta)";
+}
+
+export function formatQueryAnswer(answer, { preferMetta = false } = {}) {
   if (answer?.count_only) {
     return String(answer.count ?? "");
   }
 
-  return JSON.stringify(
-    {
-      handles: answer.handles,
-      metta: answer.metta,
-      assignment: answer.assignment
-    },
-    null,
-    2
-  );
+  if (preferMetta) {
+    const mettaLabel = formatMettaContent(answer);
+    if (mettaLabel !== "(no metta)") {
+      return mettaLabel;
+    }
+  }
+
+  return formatHandles(answer.handles);
 }

--- a/das-dashboard/src/utils/formatQueryAnswer.js
+++ b/das-dashboard/src/utils/formatQueryAnswer.js
@@ -30,11 +30,11 @@ export function formatQueryAnswer(answer, { preferMetta = false } = {}) {
   }
 
   if (preferMetta) {
-    const mettaLabel = formatMettaContent(answer);
+    const mettaLabel = formatMettaContent(answer ?? {});
     if (mettaLabel !== "(no metta)") {
       return mettaLabel;
     }
   }
 
-  return formatHandles(answer.handles);
+  return formatHandles(answer?.handles);
 }

--- a/das-dashboard/src/utils/formatQueryAnswer.js
+++ b/das-dashboard/src/utils/formatQueryAnswer.js
@@ -1,0 +1,15 @@
+export function formatQueryAnswer(answer) {
+  if (answer?.count_only) {
+    return String(answer.count ?? "");
+  }
+
+  return JSON.stringify(
+    {
+      handles: answer.handles,
+      metta: answer.metta,
+      assignment: answer.assignment
+    },
+    null,
+    2
+  );
+}

--- a/das-dashboard/src/utils/queryCharts.js
+++ b/das-dashboard/src/utils/queryCharts.js
@@ -2,9 +2,10 @@ const BUCKET_COUNT = 30;
 const WINDOW_MS = 60_000;
 
 export function buildFrequencyHistogram(answers) {
+  const streamAnswers = answers.filter((answer) => !answer.count_only);
   const labels = Array.from({ length: BUCKET_COUNT }, (_, index) => String(index + 1));
 
-  if (answers.length === 0) {
+  if (streamAnswers.length === 0) {
     return {
       counts: Array(BUCKET_COUNT).fill(0),
       labels,
@@ -13,11 +14,11 @@ export function buildFrequencyHistogram(answers) {
     };
   }
 
-  const startTime = answers[0].receivedAt;
+  const startTime = streamAnswers[0].receivedAt;
   const bucketSize = WINDOW_MS / BUCKET_COUNT;
   const counts = Array(BUCKET_COUNT).fill(0);
 
-  for (const answer of answers) {
+  for (const answer of streamAnswers) {
     const offset = answer.receivedAt - startTime;
     if (offset < 0 || offset >= WINDOW_MS) {
       continue;
@@ -36,7 +37,9 @@ export function buildFrequencyHistogram(answers) {
 }
 
 export function buildStiChart(answers, maxBars = 30) {
-  if (answers.length === 0) {
+  const stiAnswers = answers.filter((answer) => !answer.count_only);
+
+  if (stiAnswers.length === 0) {
     return {
       values: [],
       labels: [],
@@ -45,9 +48,9 @@ export function buildStiChart(answers, maxBars = 30) {
     };
   }
 
-  const slice = answers.slice(-maxBars);
-  const offset = answers.length - slice.length;
-  const values = slice.map((answer) => answer.importance);
+  const slice = stiAnswers.slice(-maxBars);
+  const offset = stiAnswers.length - slice.length;
+  const values = slice.map((answer) => Number(answer.importance ?? 0));
   const labels = slice.map((_, index) => String(offset + index + 1));
   const nonZeroCount = values.filter((value) => value !== 0).length;
 

--- a/das-dashboard/src/utils/queryCharts.js
+++ b/das-dashboard/src/utils/queryCharts.js
@@ -1,0 +1,60 @@
+const BUCKET_COUNT = 30;
+const WINDOW_MS = 60_000;
+
+export function buildFrequencyHistogram(answers) {
+  const labels = Array.from({ length: BUCKET_COUNT }, (_, index) => String(index + 1));
+
+  if (answers.length === 0) {
+    return {
+      counts: Array(BUCKET_COUNT).fill(0),
+      labels,
+      scaleLabel: "1 minute",
+      maxCount: 1
+    };
+  }
+
+  const startTime = answers[0].receivedAt;
+  const bucketSize = WINDOW_MS / BUCKET_COUNT;
+  const counts = Array(BUCKET_COUNT).fill(0);
+
+  for (const answer of answers) {
+    const offset = answer.receivedAt - startTime;
+    if (offset < 0 || offset >= WINDOW_MS) {
+      continue;
+    }
+
+    const index = Math.min(BUCKET_COUNT - 1, Math.floor(offset / bucketSize));
+    counts[index] += 1;
+  }
+
+  return {
+    counts,
+    labels,
+    scaleLabel: "1 minute",
+    maxCount: Math.max(1, ...counts)
+  };
+}
+
+export function buildStiChart(answers, maxBars = 30) {
+  if (answers.length === 0) {
+    return {
+      values: [],
+      labels: [],
+      maxValue: 1,
+      nonZeroCount: 0
+    };
+  }
+
+  const slice = answers.slice(-maxBars);
+  const offset = answers.length - slice.length;
+  const values = slice.map((answer) => answer.importance);
+  const labels = slice.map((_, index) => String(offset + index + 1));
+  const nonZeroCount = values.filter((value) => value !== 0).length;
+
+  return {
+    values,
+    labels,
+    maxValue: Math.max(0.01, ...values),
+    nonZeroCount
+  };
+}

--- a/das-dashboard/src/utils/queryCharts.js
+++ b/das-dashboard/src/utils/queryCharts.js
@@ -14,7 +14,11 @@ export function buildFrequencyHistogram(answers) {
     };
   }
 
-  const startTime = streamAnswers[0].receivedAt;
+  const endTime = Math.max(
+    Date.now(),
+    streamAnswers[streamAnswers.length - 1].receivedAt
+  );
+  const startTime = endTime - WINDOW_MS;
   const bucketSize = WINDOW_MS / BUCKET_COUNT;
   const counts = Array(BUCKET_COUNT).fill(0);
 

--- a/das-dashboard/src/utils/queryParameters.js
+++ b/das-dashboard/src/utils/queryParameters.js
@@ -1,0 +1,26 @@
+export function buildQueryParameters({
+  attentionUpdate,
+  attentionCorrelation,
+  attentionFocusStrictness,
+  maxBundleSize,
+  limitAnswersEnabled,
+  maxAnswersLimit,
+  switches
+}) {
+  return {
+    attention_update: attentionUpdate,
+    attention_correlation: attentionCorrelation,
+    attention_focus_strictness: attentionFocusStrictness,
+    max_bundle_size: maxBundleSize,
+    max_answers: limitAnswersEnabled ? maxAnswersLimit : 0,
+    unique_assignment_flag: switches.unique_assignment_flag,
+    use_link_template_cache: switches.use_link_template_cache,
+    populate_metta_mapping: switches.populate_metta_mapping,
+    use_metta_as_query_tokens: switches.use_metta_as_query_tokens,
+    allow_incomplete_chain_path: switches.allow_incomplete_chain_path,
+    positive_importance_flag: switches.positive_importance_flag,
+    disregard_importance_flag: switches.disregard_importance_flag,
+    unique_value_flag: switches.unique_value_flag,
+    count_flag: switches.count_flag
+  };
+}

--- a/das-dashboard/src/utils/queryParameters.js
+++ b/das-dashboard/src/utils/queryParameters.js
@@ -5,7 +5,7 @@ export function buildQueryParameters({
   maxBundleSize,
   limitAnswersEnabled,
   maxAnswersLimit,
-  switches
+  switches = {}
 }) {
   return {
     attention_update: attentionUpdate,


### PR DESCRIPTION
Implemented a UI for querying AtomDBs.

### Features

* Sidebar for configuring query parameters
* Text editor for writing query tokens or MeTTa queries
* Graphs for visualizing STI and answers per second
* Query results list with an interactive, paginated modal for browsing all returned answers

### Demo

The demo video showcases three different query workflows:

* Running a standard MeTTa query
* Running a MeTTa query with "Populate MeTTa mapping" turned off.
* Running a count-only query
* Running a non-MeTTa query using MeTTa syntax (results in an error because i'm using MeTTa)

Video:

[Screencast from 2026-07-27 14-40-00.webm](https://github.com/user-attachments/assets/68ca555f-bc9e-4b72-adce-4af38730c968)
