### PR TITLE
[DAS-Dashboard#1193] Error in metrics overview

### DIFF
--- a/das-cli/src/commands/query_agent/query_agent_cli.py
+++ b/das-cli/src/commands/query_agent/query_agent_cli.py
@@ -229,7 +229,7 @@ class QueryAgentRestart(Command):
 class QueryAgentCli(CommandGroup):
     name = "query-agent"
 
-    aliases = ["qa", "query"]
+    aliases = ["qa", "query", "query-engine", "qe"]
 
     short_help = SHORT_HELP_QA
     help = HELP_QA

--- a/das-cli/src/common/container_manager/metta/metta_syntax_container_manager.py
+++ b/das-cli/src/common/container_manager/metta/metta_syntax_container_manager.py
@@ -10,6 +10,7 @@ from settings.config import METTA_PARSER_IMAGE_NAME, METTA_PARSER_IMAGE_VERSION
 
 class MettaSyntaxContainerManager(ContainerManager):
     def __init__(self) -> None:
+
         container = Container(
             "das-metta-parser",
             metadata=ContainerMetadata(
@@ -23,6 +24,8 @@ class MettaSyntaxContainerManager(ContainerManager):
                 }
             ),
         )
+
+        self._options = {"service_name": "Metta Syntax Check", "service_command_label": "metta"}
 
         super().__init__(container)
 

--- a/das-cli/src/common/container_manager/system_containers_manager.py
+++ b/das-cli/src/common/container_manager/system_containers_manager.py
@@ -20,7 +20,7 @@ class SystemContainersManager(DockerManager):
         self._settings = settings
 
     def _list_service_containers(self) -> list[Container]:
-        return self.get_docker_client().containers.list(filters={"name": "das"})
+        return self.get_docker_client().containers.list(filters={"label": "das-cli.managed=true"})
 
     def get_services_status(self) -> dict:
 
@@ -36,6 +36,7 @@ class SystemContainersManager(DockerManager):
 
     def _safe_get_container_stats(self, container: Container) -> dict:
         try:
+            container_labels : dict = container.labels
             container_stats = container.stats(stream=False)
             cpu_memory_info = self._parse_container_stats(container_stats)
 
@@ -48,6 +49,8 @@ class SystemContainersManager(DockerManager):
 
             return {
                 "container_name": container_name,
+                "service_name": container_labels.get("agent.name", None),
+                "service_command_label": container_labels.get("command.label", None),
                 "image": image,
                 "port": port,
                 "age": age,

--- a/das-cli/src/common/container_manager/system_containers_manager.py
+++ b/das-cli/src/common/container_manager/system_containers_manager.py
@@ -36,7 +36,7 @@ class SystemContainersManager(DockerManager):
 
     def _safe_get_container_stats(self, container: Container) -> dict:
         try:
-            container_labels : dict = container.labels
+            container_labels: dict = container.labels
             container_stats = container.stats(stream=False)
             cpu_memory_info = self._parse_container_stats(container_stats)
 
@@ -49,8 +49,8 @@ class SystemContainersManager(DockerManager):
 
             return {
                 "container_name": container_name,
-                "service_name": container_labels.get("agent.name", None),
-                "service_command_label": container_labels.get("command.label", None),
+                "service_name": container_labels.get("das-cli.service.name", None),
+                "service_command_label": container_labels.get("das-cli.command.label", None),
                 "image": image,
                 "port": port,
                 "age": age,

--- a/das-cli/src/common/docker/container_manager.py
+++ b/das-cli/src/common/docker/container_manager.py
@@ -93,6 +93,13 @@ class ContainerManager(DockerManager):
         except docker.errors.APIError as e:
             raise DockerError(e.explanation)
 
+    @property
+    def labels(self):
+        return {
+            "agent.name": self._options["service_name"],
+            "command.label": self._options["service_command_label"]
+        }
+
     def _start_container(self, **kwargs) -> Any:
         self.raise_running_container()
 
@@ -103,6 +110,10 @@ class ContainerManager(DockerManager):
                 name=self.get_container().name,
                 detach=True,
                 network=SERVICES_NETWORK_NAME,
+                labels={
+                    "das-cli.managed": "true",
+                    **self.labels
+                }
             )
 
             return response

--- a/das-cli/src/common/docker/container_manager.py
+++ b/das-cli/src/common/docker/container_manager.py
@@ -72,6 +72,7 @@ class ContainerManager(DockerManager):
         exec_context: Union[str, None] = None,
     ) -> None:
         super().__init__(exec_context)
+        self._options: dict[str, Any]
         self._container = container
 
     def get_container(self) -> Container:
@@ -95,9 +96,22 @@ class ContainerManager(DockerManager):
 
     @property
     def labels(self):
+
+        REQUIRED_LABELS = ["service_name", "service_command_label"]
+        missing = []
+
+        for label in REQUIRED_LABELS:
+            if label not in self._options:
+                missing.append(label)
+
+        if missing:
+            raise KeyError(
+                f"Internal error in das-cli, could not find required values to form container metadata.\n Missing keys {' '.join(missing)}"
+            )
+
         return {
-            "agent.name": self._options["service_name"],
-            "command.label": self._options["service_command_label"]
+            "das-cli.service.name": self._options.get("service_name"),
+            "das-cli.command.label": self._options.get("service_command_label"),
         }
 
     def _start_container(self, **kwargs) -> Any:
@@ -110,13 +124,11 @@ class ContainerManager(DockerManager):
                 name=self.get_container().name,
                 detach=True,
                 network=SERVICES_NETWORK_NAME,
-                labels={
-                    "das-cli.managed": "true",
-                    **self.labels
-                }
+                labels={"das-cli.managed": "true", **self.labels},
             )
 
             return response
+
         except docker.errors.APIError as e:
             if e.response.status_code == 404:
                 raise DockerContainerNotFoundError(

--- a/das-cli/src/common/factory/atomdb/mongodb_manager_factory.py
+++ b/das-cli/src/common/factory/atomdb/mongodb_manager_factory.py
@@ -41,6 +41,8 @@ class MongoDbContainerManagerFactory:
         return MongodbContainerManager(
             container_name,
             options={
+                "service_name": "MongoDB",
+                "service_command_label": "db",
                 "mongodb_endpoint": mongodb_endpoint,
                 "mongodb_port": mongodb_port,
                 "mongodb_username": mongodb_username,

--- a/das-cli/src/common/factory/atomdb/morkdb_manager_factory.py
+++ b/das-cli/src/common/factory/atomdb/morkdb_manager_factory.py
@@ -32,7 +32,7 @@ class MorkDbContainerManagerFactory:
         return MorkdbContainerManager(
             container_name,
             options={
-                "service_name":"MorkDB",
+                "service_name": "MorkDB",
                 "service_command_label": "db",
                 "morkdb_endpoint": morkdb_endpoint,
                 "morkdb_port": morkdb_port,

--- a/das-cli/src/common/factory/atomdb/morkdb_manager_factory.py
+++ b/das-cli/src/common/factory/atomdb/morkdb_manager_factory.py
@@ -32,6 +32,8 @@ class MorkDbContainerManagerFactory:
         return MorkdbContainerManager(
             container_name,
             options={
+                "service_name":"MorkDB",
+                "service_command_label": "db",
                 "morkdb_endpoint": morkdb_endpoint,
                 "morkdb_port": morkdb_port,
                 "morkdb_hostname": "0.0.0.0" if morkdb_hostname == "localhost" else morkdb_hostname,

--- a/das-cli/src/common/factory/atomdb/redis_manager_factory.py
+++ b/das-cli/src/common/factory/atomdb/redis_manager_factory.py
@@ -36,6 +36,8 @@ class RedisContainerManagerFactory:
         return RedisContainerManager(
             container_name,
             options={
+                "service_name": "Redis",
+                "service_command_label": "db",
                 "redis_endpoint": redis_endpoint,
                 "redis_port": redis_port,
                 "redis_nodes": redis_nodes,

--- a/das-cli/src/common/factory/attention_broker_manager_factory.py
+++ b/das-cli/src/common/factory/attention_broker_manager_factory.py
@@ -24,5 +24,7 @@ class AttentionBrokerManagerFactory:
             options={
                 "attention_broker_hostname": "0.0.0.0",
                 "attention_broker_port": attention_broker_port,
+                "service_name": "Attention Broker",
+                "service_command_label": "attention-broker",
             },
         )

--- a/das-cli/src/common/factory/busnode_manager_factory.py
+++ b/das-cli/src/common/factory/busnode_manager_factory.py
@@ -23,7 +23,6 @@ class BusNodeContainerManagerFactory:
             formatted_name = service_name.capitalize()
             return formatted_name
 
-
     def build(self, use_settings_from: str, service_name: str) -> BusNodeContainerManager:
         service_port = extract_service_port(self._settings.get(f"{use_settings_from}.endpoint"))
 

--- a/das-cli/src/common/factory/busnode_manager_factory.py
+++ b/das-cli/src/common/factory/busnode_manager_factory.py
@@ -12,6 +12,18 @@ class BusNodeContainerManagerFactory:
     def __init__(self):
         self._settings = Settings(store=JsonConfigStore(os.path.expanduser(SECRETS_PATH)))
 
+    def format_service_name(self, service_name: str) -> str:
+
+        if service_name.__contains__("-"):
+            formatted_name = service_name.replace("-", " ").title()
+
+            return formatted_name
+
+        else:
+            formatted_name = service_name.capitalize()
+            return formatted_name
+
+
     def build(self, use_settings_from: str, service_name: str) -> BusNodeContainerManager:
         service_port = extract_service_port(self._settings.get(f"{use_settings_from}.endpoint"))
 
@@ -37,6 +49,8 @@ class BusNodeContainerManagerFactory:
             default_container_name,
             options={
                 "service": service_name,
+                "service_name": self.format_service_name(service_name),
+                "service_command_label": service_name,
                 "service_port": service_port,
                 "service_endpoint": service_endpoint,
                 "attention_broker_hostname": attention_broker_hostname,

--- a/das-cli/src/common/factory/database_adapter/database_adapter_factory.py
+++ b/das-cli/src/common/factory/database_adapter/database_adapter_factory.py
@@ -26,5 +26,7 @@ class DatabaseAdapterFactory:
             options={
                 "context_mapping_paths": context_mapping_paths,
                 "metta_output_dir": metta_output_dir,
+                "service_name": "Database Adapter",
+                "service_command_label": "database-adapter",
             },
         )

--- a/das-cli/src/common/factory/jupyter_notebook_manager_factory.py
+++ b/das-cli/src/common/factory/jupyter_notebook_manager_factory.py
@@ -26,5 +26,7 @@ class JupyterNotebookManagerFactory:
             options={
                 "jupyter_notebook_port": jupyter_notebook_port,
                 "jupyter_notebook_hostname": jupyter_notebook_hostname,
+                "service_name": "Jupyter Notebook",
+                "service_command_label": "jupyter-notebook",
             },
         )

--- a/das-cli/src/common/factory/metta/database_loader_manager_factory.py
+++ b/das-cli/src/common/factory/metta/database_loader_manager_factory.py
@@ -19,5 +19,8 @@ class DatabaseLoaderContainerManagerFactory:
 
         return DatabaseLoaderContainerManager(
             container_name,
-            options={},
+            options={
+                "service_name": "Metta Loader",
+                "service_command_label": "metta",
+            },
         )


### PR DESCRIPTION
Fixed an issue where containers not started by DAS-CLI could still appear in the UI:
* Added container labels to improve filtering and attach useful metadata.
* Updated the filtering logic to ensure that only containers containing the label "das-cli.managed=true" are displayed, preventing third-party or externally created containers from appearing in the UI.

Quick showcase:
(The service running outside of das-cli's environment was the command-router, as you can see it doesn't show up anymore on the UI)


[Screencast from 2026-08-04 13-47-07.webm](https://github.com/user-attachments/assets/2bf7ddb3-d892-4b50-b0f7-e33aa7b7a8cc)
